### PR TITLE
Trace hash_graph and fuse_optimizers with Scalopus

### DIFF
--- a/fuse_graphs/CMakeLists.txt
+++ b/fuse_graphs/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(fuse_graphs)
 
 set(build_depends
+  cpr_scalopus
   fuse_core
   roscpp
 )

--- a/fuse_graphs/package.xml
+++ b/fuse_graphs/package.xml
@@ -11,6 +11,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <depend>cpr_scalopus</depend>
   <depend>libceres-dev</depend>
   <depend>fuse_core</depend>
   <depend>roscpp</depend>

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -34,6 +34,8 @@
 #include <fuse_graphs/hash_graph.h>
 #include <fuse_core/uuid.h>
 
+#include <cpr_scalopus/common.h>
+
 #include <boost/iterator/transform_iterator.hpp>
 
 #include <algorithm>
@@ -290,6 +292,8 @@ void HashGraph::getCovariance(
   const ceres::Covariance::Options& options,
   const bool use_tangent_space) const
 {
+  TRACE_PRETTY_FUNCTION();
+
   // Avoid doing a bunch of work if the request is empty
   if (covariance_requests.empty())
   {
@@ -399,6 +403,8 @@ void HashGraph::getCovariance(
 
 ceres::Solver::Summary HashGraph::optimize(const ceres::Solver::Options& options)
 {
+  TRACE_PRETTY_FUNCTION();
+
   // Construct the ceres::Problem object from scratch
   ceres::Problem problem(problem_options_);
   createProblem(problem);
@@ -429,6 +435,8 @@ void HashGraph::print(std::ostream& stream) const
 
 void HashGraph::createProblem(ceres::Problem& problem) const
 {
+  TRACE_PRETTY_FUNCTION();
+
   // Add all the variables to the problem
   for (auto& uuid__variable : variables_)
   {

--- a/fuse_optimizers/CMakeLists.txt
+++ b/fuse_optimizers/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(fuse_optimizers)
 
 set(build_depends
+  cpr_scalopus
   fuse_constraints
   fuse_core
   fuse_graphs

--- a/fuse_optimizers/package.xml
+++ b/fuse_optimizers/package.xml
@@ -14,6 +14,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <depend>cpr_scalopus</depend>
   <depend>fuse_constraints</depend>
   <depend>fuse_core</depend>
   <depend>fuse_graphs</depend>

--- a/fuse_optimizers/src/batch_optimizer_node.cpp
+++ b/fuse_optimizers/src/batch_optimizer_node.cpp
@@ -35,11 +35,17 @@
 #include <fuse_optimizers/batch_optimizer.h>
 #include <ros/ros.h>
 
+#include <cpr_scalopus/common.h>
+
 
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "batch_optimizer_node");
   fuse_optimizers::BatchOptimizer optimizer(fuse_graphs::HashGraph::make_unique());
+
+  auto exposer = cpr_scalopus::DefaultExposer(ros::this_node::getName());
+  TRACE_THREAD_NAME("main");
+
   ros::spin();
 
   return 0;

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -40,6 +40,8 @@
 #include <fuse_optimizers/optimizer.h>
 #include <ros/ros.h>
 
+#include <cpr_scalopus/common.h>
+
 #include <algorithm>
 #include <iterator>
 #include <mutex>
@@ -141,6 +143,8 @@ void FixedLagSmoother::postprocessMarginalization(const fuse_core::Transaction& 
 
 void FixedLagSmoother::optimizationLoop()
 {
+  TRACE_THREAD_NAME("Optimization Loop");
+
   auto exit_wait_condition = [this]()
   {
     return this->optimization_request_ || !this->optimization_running_ || !ros::ok();
@@ -162,6 +166,8 @@ void FixedLagSmoother::optimizationLoop()
     }
     // Optimize
     {
+      TRACE_SCOPE_RAII("Optimize");
+
       std::lock_guard<std::mutex> lock(optimization_mutex_);
       // Apply motion models
       auto new_transaction = fuse_core::Transaction::make_shared();
@@ -224,6 +230,8 @@ void FixedLagSmoother::optimizerTimerCallback(const ros::TimerEvent& event)
 
 void FixedLagSmoother::processQueue(fuse_core::Transaction& transaction)
 {
+  TRACE_PRETTY_FUNCTION();
+
   // We need to get the pending transactions from the queue
   std::lock_guard<std::mutex> pending_transactions_lock(pending_transactions_mutex_);
   // Use the most recent transaction time as the current time

--- a/fuse_optimizers/src/fixed_lag_smoother_node.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother_node.cpp
@@ -35,11 +35,17 @@
 #include <fuse_optimizers/fixed_lag_smoother.h>
 #include <ros/ros.h>
 
+#include <cpr_scalopus/common.h>
+
 
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "fixed_lag_smoother_node");
   fuse_optimizers::FixedLagSmoother optimizer(fuse_graphs::HashGraph::make_unique());
+
+  auto exposer = cpr_scalopus::DefaultExposer(ros::this_node::getName());
+  TRACE_THREAD_NAME("main");
+
   ros::spin();
 
   return 0;

--- a/fuse_optimizers/src/optimizer.cpp
+++ b/fuse_optimizers/src/optimizer.cpp
@@ -40,6 +40,8 @@
 #include <ros/init.h>
 #include <ros/node_handle.h>
 
+#include <cpr_scalopus/common.h>
+
 #include <XmlRpcValue.h>
 
 #include <functional>
@@ -226,6 +228,8 @@ bool Optimizer::applyMotionModels(
   const std::string& sensor_name,
   fuse_core::Transaction& transaction) const
 {
+  TRACE_PRETTY_FUNCTION();
+
   // Check for trivial cases where we don't have to do anything
   auto iter = associated_motion_models_.find(sensor_name);
   if (iter == associated_motion_models_.end())
@@ -316,6 +320,8 @@ void Optimizer::clearCallbacks()
 
 void Optimizer::startPlugins()
 {
+  TRACE_PRETTY_FUNCTION();
+
   for (const auto& name_plugin : motion_models_)
   {
     name_plugin.second->start();
@@ -332,6 +338,8 @@ void Optimizer::startPlugins()
 
 void Optimizer::stopPlugins()
 {
+  TRACE_PRETTY_FUNCTION();
+
   for (const auto& name_plugin : publishers_)
   {
     name_plugin.second->stop();


### PR DESCRIPTION
This adds tracepoints to the `HashGraph` class and the `fuse_optimizers` using [scalopus](https://github.com/iwanders/scalopus).

This relies on the private ROS package `cpr_scalopus`. That's why this PR is against `cpr-devel` and in our fork.

Example:
![t2_fuse_rl_scalopus](https://user-images.githubusercontent.com/382167/62225307-79c7c380-b3b8-11e9-87ba-573cf679f8b9.gif)
