### PR TITLE
Add TRACE_COUNT_SERIES for graph and transaction

### DIFF
--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(fuse_core)
 
 set(build_depends
+  cpr_scalopus
   fuse_msgs
   pluginlib
   roscpp

--- a/fuse_core/package.xml
+++ b/fuse_core/package.xml
@@ -12,6 +12,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <depend>cpr_scalopus</depend>
   <depend>libceres-dev</depend>
   <depend>eigen</depend>
   <depend>fuse_msgs</depend>

--- a/fuse_core/src/graph.cpp
+++ b/fuse_core/src/graph.cpp
@@ -36,7 +36,10 @@
 #include <fuse_core/transaction.h>
 #include <fuse_core/uuid.h>
 
+#include <cpr_scalopus/common.h>
+
 #include <boost/iterator/transform_iterator.hpp>
+#include <boost/range.hpp>
 
 #include <functional>
 
@@ -71,6 +74,10 @@ void Graph::update(const Transaction& transaction)
   // Update the graph with a new transaction. In order to keep the graph consistent, variables are added first,
   // followed by the constraints which might use the newly added variables. Then constraints are removed so that
   // the variable usage is updated. Finally, variables are removed.
+  TRACE_COUNT_SERIES("transaction", "added_variables", boost::size(transaction.addedVariables()));
+  TRACE_COUNT_SERIES("transaction", "added_constraints", boost::size(transaction.addedConstraints()));
+  TRACE_COUNT_SERIES("transaction", "removed_constraints", boost::size(transaction.removedConstraints()));
+  TRACE_COUNT_SERIES("transaction", "removed_variables", boost::size(transaction.removedVariables()));
 
   // Insert the new variables into the graph
   for (const auto& variable : transaction.addedVariables())

--- a/fuse_graphs/src/hash_graph.cpp
+++ b/fuse_graphs/src/hash_graph.cpp
@@ -407,6 +407,8 @@ void HashGraph::getCovariance(
 ceres::Solver::Summary HashGraph::optimize(const ceres::Solver::Options& options)
 {
   TRACE_PRETTY_FUNCTION();
+  TRACE_COUNT_SERIES("graph", "variables", variables_.size());
+  TRACE_COUNT_SERIES("graph", "constraints", constraints_.size());
 
   // Construct the ceres::Problem object from scratch
   ceres::Problem problem(problem_options_);


### PR DESCRIPTION
This adds `TRACE_COUNT_SERIES`, which are now supported by Scalopus, for:
* graph variables and constraints
* transaction variables and constraints added and removed

Example trace with these count series:
![Screenshot from 2019-09-27 21-41-19](https://user-images.githubusercontent.com/382167/65797512-b2dda380-e16f-11e9-97dd-11129992c265.png)
