### PR TITLE
[CORE-14776] Allow to predict odometry

### DIFF
--- a/fuse_models/include/fuse_models/odometry_2d_publisher.h
+++ b/fuse_models/include/fuse_models/odometry_2d_publisher.h
@@ -92,7 +92,7 @@ namespace fuse_models
 class Odometry2DPublisher : public fuse_core::AsyncPublisher
 {
 public:
-  SMART_PTR_DEFINITIONS(Odometry2DPublisher);
+  SMART_PTR_DEFINITIONS_WITH_EIGEN(Odometry2DPublisher);
   using ParameterType = parameters::Odometry2DPublisherParams;
 
   /**
@@ -173,6 +173,8 @@ protected:
   ParameterType params_;
 
   ros::Time latest_stamp_;
+
+  ros::Time latest_covariance_stamp_;
 
   nav_msgs::Odometry odom_output_;
 

--- a/fuse_models/include/fuse_models/unicycle_2d_predict.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_predict.h
@@ -36,6 +36,7 @@
 
 #include <ceres/jet.h>
 #include <fuse_core/util.h>
+#include <fuse_core/eigen.h>
 #include <tf2_2d/tf2_2d.h>
 
 
@@ -100,6 +101,105 @@ inline void predict(
   fuse_core::wrapAngle2D(yaw2);
 }
 
+enum StateIndex : uint8_t
+{
+  X,
+  Y,
+  YAW,
+  V_X,
+  V_Y,
+  V_YAW,
+  A_X,
+  A_Y
+};
+
+/**
+ * @brief Given a state and time delta, predicts a new state
+ * @param[in] position1_x - First X position
+ * @param[in] position1_y - First Y position
+ * @param[in] yaw1 - First orientation
+ * @param[in] vel_linear1_x - First X velocity
+ * @param[in] vel_linear1_y - First Y velocity
+ * @param[in] vel_yaw1 - First yaw velocity
+ * @param[in] acc_linear1_x - First X acceleration
+ * @param[in] acc_linear1_y - First Y acceleration
+ * @param[in] dt - The time delta across which to predict the state
+ * @param[in] position2_x - Second X position
+ * @param[in] position2_y - Second Y position
+ * @param[in] yaw2 - Second orientation
+ * @param[in] vel_linear2_x - Second X velocity
+ * @param[in] vel_linear2_y - Second Y velocity
+ * @param[in] vel_yaw2 - Second yaw velocity
+ * @param[in] acc_linear2_x - Second X acceleration
+ * @param[in] acc_linear2_y - Second Y acceleration
+ * @param[in] jacobians - Jacobians wrt the state
+ */
+// TODO fuse this with the templated predict function so we can use the analytic Jacobian in the cost function.
+// See http://ceres-solver.org/analytical_derivatives.html
+inline void predict(
+  const double position1_x,
+  const double position1_y,
+  const double yaw1,
+  const double vel_linear1_x,
+  const double vel_linear1_y,
+  const double vel_yaw1,
+  const double acc_linear1_x,
+  const double acc_linear1_y,
+  const double dt,
+  double& position2_x,
+  double& position2_y,
+  double& yaw2,
+  double& vel_linear2_x,
+  double& vel_linear2_y,
+  double& vel_yaw2,
+  double& acc_linear2_x,
+  double& acc_linear2_y,
+  // TODO double** jacobians didn't play well with Eigen::Map<>, at least directly
+  double* jacobians)
+{
+  const double sy = ceres::sin(yaw1);
+  const double cy = ceres::cos(yaw1);
+
+  const double half_dt2 = 0.5 * dt * dt;
+  const double delta_x = vel_linear1_x * dt + acc_linear1_x * half_dt2;
+  const double delta_y = vel_linear1_y * dt + acc_linear1_y * half_dt2;
+
+  const double delta_x_rot = cy * delta_x - sy * delta_y;
+  const double delta_y_rot = sy * delta_x + cy * delta_y;
+
+  position2_x = position1_x + delta_x_rot;
+  position2_y = position1_y + delta_y_rot;
+  yaw2 = yaw1 + vel_yaw1 * dt;
+  vel_linear2_x = vel_linear1_x + acc_linear1_x * dt;
+  vel_linear2_y = vel_linear1_y + acc_linear1_y * dt;
+  vel_yaw2 = vel_yaw1;
+  acc_linear2_x = acc_linear1_x;
+  acc_linear2_y = acc_linear1_y;
+
+  fuse_core::wrapAngle2D(yaw2);
+
+  if (!jacobians)
+  {
+    return;
+  }
+
+  Eigen::Map<fuse_core::Matrix8d> J(jacobians);
+  J.setIdentity();
+  J(X, YAW) = -delta_y_rot;
+  J(X, V_X) = cy * dt;
+  J(Y, V_X) = sy * dt;
+  J(X, V_Y) = -J(Y, V_X);
+  J(X, A_X) = 0.5 * J(X, V_X) * dt;
+  J(X, A_Y) = 0.5 * J(X, V_Y) * dt;
+  J(Y, YAW) = delta_x_rot;
+  J(Y, V_Y) = J(X, V_X);
+  J(Y, A_X) = -J(X, A_Y);
+  J(Y, A_Y) = J(X, A_X);
+  J(YAW, V_YAW) = dt;
+  J(V_X, A_X) = dt;
+  J(V_Y, A_Y) = dt;
+}
+
 /**
  * @brief Given a state and time delta, predicts a new state
  * @param[in] position1 - First position (array with x at index 0, y at index 1)
@@ -146,6 +246,68 @@ inline void predict(
     *vel_yaw2,
     acc_linear2[0],
     acc_linear2[1]);
+}
+
+/**
+ * @brief Given a state and time delta, predicts a new state
+ * @param[in] pose1 - The first 2D pose
+ * @param[in] vel_linear_1 - The first linear velocity
+ * @param[in] vel_yaw1 - The first yaw velocity
+ * @param[in] acc_linear1 - The first linear acceleration
+ * @param[in] dt - The time delta across which to predict the state
+ * @param[in] pose2 - The second 2D pose
+ * @param[in] vel_linear_2 - The second linear velocity
+ * @param[in] vel_yaw2 - The second yaw velocity
+ * @param[in] acc_linear2 - The second linear acceleration
+ * @param[in] jacobian - The jacobian wrt the state
+ */
+inline void predict(
+  const tf2_2d::Transform& pose1,
+  const tf2_2d::Vector2& vel_linear1,
+  const double vel_yaw1,
+  const tf2_2d::Vector2& acc_linear1,
+  const double dt,
+  tf2_2d::Transform& pose2,
+  tf2_2d::Vector2& vel_linear2,
+  double& vel_yaw2,
+  tf2_2d::Vector2& acc_linear2,
+  fuse_core::Matrix8d& jacobian)
+{
+  double x_pred {};
+  double y_pred {};
+  double yaw_pred {};
+  double vel_linear_x_pred {};
+  double vel_linear_y_pred {};
+  double acc_linear_x_pred {};
+  double acc_linear_y_pred {};
+
+  predict(
+    pose1.x(),
+    pose1.y(),
+    pose1.yaw(),
+    vel_linear1.x(),
+    vel_linear1.y(),
+    vel_yaw1,
+    acc_linear1.x(),
+    acc_linear1.y(),
+    dt,
+    x_pred,
+    y_pred,
+    yaw_pred,
+    vel_linear_x_pred,
+    vel_linear_y_pred,
+    vel_yaw2,
+    acc_linear_x_pred,
+    acc_linear_y_pred,
+    jacobian.data());
+
+  pose2.setX(x_pred);
+  pose2.setY(y_pred);
+  pose2.setYaw(yaw_pred);
+  vel_linear2.setX(vel_linear_x_pred);
+  vel_linear2.setY(vel_linear_y_pred);
+  acc_linear2.setX(acc_linear_x_pred);
+  acc_linear2.setY(acc_linear_y_pred);
 }
 
 /**

--- a/fuse_models/include/fuse_models/unicycle_2d_state_cost_functor.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_state_cost_functor.h
@@ -52,6 +52,7 @@ namespace fuse_models
  *   y position
  *   yaw (rotation about the z axis)
  *   x velocity
+ *   y velocity
  *   yaw velocity
  *   x acceleration
  *   y acceleration

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -35,6 +35,7 @@
 #include <fuse_models/unicycle_2d_predict.h>
 
 #include <fuse_core/async_publisher.h>
+#include <fuse_core/eigen.h>
 #include <fuse_core/uuid.h>
 
 #include <nav_msgs/Odometry.h>
@@ -60,7 +61,8 @@ namespace fuse_models
 Odometry2DPublisher::Odometry2DPublisher() :
   fuse_core::AsyncPublisher(1),
   device_id_(fuse_core::uuid::NIL),
-  latest_stamp_(Synchronizer::TIME_ZERO)
+  latest_stamp_(Synchronizer::TIME_ZERO),
+  latest_covariance_stamp_(Synchronizer::TIME_ZERO)
 {
 }
 
@@ -161,6 +163,8 @@ void Odometry2DPublisher::notifyCallback(
       odom_output_.twist.covariance[30] = covariance_matrices[4][0];
       odom_output_.twist.covariance[31] = covariance_matrices[4][1];
       odom_output_.twist.covariance[35] = covariance_matrices[5][0];
+
+      latest_covariance_stamp_ = latest_stamp_;
     }
     catch (const std::exception& e)
     {
@@ -171,7 +175,11 @@ void Odometry2DPublisher::notifyCallback(
       std::fill(odom_output_.pose.covariance.begin(), odom_output_.pose.covariance.end(), 0.0);
       std::fill(odom_output_.twist.covariance.begin(), odom_output_.twist.covariance.end(), 0.0);
     }
-    odom_pub_.publish(odom_output_);
+
+    if (!params_.predict_odom)
+    {
+      odom_pub_.publish(odom_output_);
+    }
   }
 }
 
@@ -181,7 +189,7 @@ void Odometry2DPublisher::onStart()
   TRACE_PRETTY_FUNCTION();
 
   synchronizer_ = Synchronizer(device_id_);
-  latest_stamp_ = Synchronizer::TIME_ZERO;
+  latest_stamp_ = latest_covariance_stamp_ = Synchronizer::TIME_ZERO;
   odom_output_ = nav_msgs::Odometry();
   tf_publish_timer_.start();
 }
@@ -267,21 +275,114 @@ void Odometry2DPublisher::tfPublishTimerCallback(const ros::TimerEvent& event)
     tf2_2d::Vector2 velocity_linear;
     tf2::fromMsg(odom_output_.twist.twist.linear, velocity_linear);
 
-    tf2_2d::Vector2 unused_acc;
-    double unused_yaw_vel;
+    const double dt = event.current_real.toSec() - odom_output_.header.stamp.toSec();
 
-    predict(
-      pose,
-      velocity_linear,
-      odom_output_.twist.twist.angular.z,
-      unused_acc,
-      event.current_real.toSec() - odom_output_.header.stamp.toSec(),
-      pose,
-      velocity_linear,
-      unused_yaw_vel,
-      unused_acc);
+    if (params_.predict_odom)
+    {
+      fuse_core::Matrix8d jacobian;
 
-    trans.header.stamp = event.current_real;
+      tf2_2d::Vector2 unused_acc;
+      double yaw_vel;
+
+      predict(
+        pose,
+        velocity_linear,
+        odom_output_.twist.twist.angular.z,
+        // TODO we should use the actual acceleration, both here and in the else, even if we don't care of the
+        // resulting acceleration, because it also affects other components
+        unused_acc,
+        dt,
+        pose,
+        velocity_linear,
+        yaw_vel,
+        unused_acc,
+        jacobian);
+
+      odom_output_.pose.pose.position.x = pose.getX();
+      odom_output_.pose.pose.position.y = pose.getY();
+      odom_output_.pose.pose.orientation = tf2::toMsg(pose.getRotation());
+
+      odom_output_.twist.twist.linear.x = velocity_linear.x();
+      odom_output_.twist.twist.linear.y = velocity_linear.y();
+      odom_output_.twist.twist.angular.z = yaw_vel;
+
+      odom_output_.header.stamp = event.current_real;
+
+      // Either the last covariance computation was skipped because there was no subscriber,
+      // or if failed
+      if (latest_covariance_stamp_ == latest_stamp_)
+      {
+        Eigen::Matrix<double, 6, 6> covariance;
+        covariance(0, 0) = odom_output_.pose.covariance[0];
+        covariance(0, 1) = odom_output_.pose.covariance[1];
+        covariance(0, 2) = odom_output_.pose.covariance[5];
+        covariance(1, 0) = odom_output_.pose.covariance[6];
+        covariance(1, 1) = odom_output_.pose.covariance[7];
+        covariance(1, 2) = odom_output_.pose.covariance[11];
+        covariance(2, 0) = odom_output_.pose.covariance[30];
+        covariance(2, 1) = odom_output_.pose.covariance[31];
+        covariance(2, 2) = odom_output_.pose.covariance[35];
+
+        covariance(3, 3) = odom_output_.twist.covariance[0];
+        covariance(3, 4) = odom_output_.twist.covariance[1];
+        covariance(3, 5) = odom_output_.twist.covariance[5];
+        covariance(4, 3) = odom_output_.twist.covariance[6];
+        covariance(4, 4) = odom_output_.twist.covariance[7];
+        covariance(4, 5) = odom_output_.twist.covariance[11];
+        covariance(5, 3) = odom_output_.twist.covariance[30];
+        covariance(5, 4) = odom_output_.twist.covariance[31];
+        covariance(5, 5) = odom_output_.twist.covariance[35];
+
+        // TODO for now we set the top right and bottom left corners to zero, but we could cache them in another attribute
+        // when we retrieve the covariance from the ceres problem
+        covariance.topRightCorner<3, 3>().setZero();
+        covariance.bottomLeftCorner<3, 3>().setZero();
+
+        const Eigen::Matrix<double, 6, 6> J = jacobian.topLeftCorner<6, 6>();
+        covariance = J * covariance * J.transpose();
+        covariance.noalias() += dt * params_.process_noise_covariance.topLeftCorner<6, 6>();
+
+        odom_output_.pose.covariance[0] = covariance(0, 0);
+        odom_output_.pose.covariance[1] = covariance(0, 1);
+        odom_output_.pose.covariance[5] = covariance(0, 2);
+        odom_output_.pose.covariance[6] = covariance(1, 0);
+        odom_output_.pose.covariance[7] = covariance(1, 1);
+        odom_output_.pose.covariance[11] = covariance(1, 2);
+        odom_output_.pose.covariance[30] = covariance(2, 0);
+        odom_output_.pose.covariance[31] = covariance(2, 1);
+        odom_output_.pose.covariance[35] = covariance(2, 2);
+
+        odom_output_.twist.covariance[0] = covariance(3, 3);
+        odom_output_.twist.covariance[1] = covariance(3, 4);
+        odom_output_.twist.covariance[5] = covariance(3, 5);
+        odom_output_.twist.covariance[6] = covariance(4, 3);
+        odom_output_.twist.covariance[7] = covariance(4, 4);
+        odom_output_.twist.covariance[11] = covariance(4, 5);
+        odom_output_.twist.covariance[30] = covariance(5, 3);
+        odom_output_.twist.covariance[31] = covariance(5, 4);
+        odom_output_.twist.covariance[35] = covariance(5, 5);
+      }
+
+      odom_pub_.publish(odom_output_);
+    }
+    else
+    {
+      tf2_2d::Vector2 unused_acc;
+      double unused_yaw_vel;
+
+      predict(
+        pose,
+        velocity_linear,
+        odom_output_.twist.twist.angular.z,
+        unused_acc,
+        dt,
+        pose,
+        velocity_linear,
+        unused_yaw_vel,
+        unused_acc);
+
+      trans.header.stamp = event.current_real;
+    }
   }
 
   trans.transform.translation.x = pose.getX();


### PR DESCRIPTION
* Add `predict_odom` parameter that:
  1. Disables publishing the odometry in the `notifyCallback`
  2. Enables publishing the odometry in the `tfPublishTimerCallback`, predicting it into the current time.
     The Jacobian of the motion model used in the predict function is computed so the odometry covariance can be propagated.
     The odometry cached in the class is updated with the predicted pose, covariance and time stamp.
* Add `process_noise_diagonal` parameter that defines the diagonal of the process noise covariance that is added to the propagated covariance computing after predicting the odometry into the current time.
  The process noise covariance has 8x8 size, so it can represent all the state, although the acceleration is ignored at the moment.
* Add new `predict` free functions to compute the Jacobian of the motion model wrt the state. Two versions are provided:
  1. One that takes each single component and a plain array of double to
     the Jacobian.
  2. Another that takes aggregate objects like `tf2_2d::Transform` and an `fuse_core::Matrix8d` for the Jacobian.
* Cache the stamp of the latest covariance successfully computed in the `notifyCallback`, so it's possible to know if the covariance is valid and up to date in the `tfPublishTimerCallback`.
  If the covariance is invalid or not up to date, no time is wasted propagating it.