### PR TITLE
[CORE-15382] Scale process noise covariance

### DIFF
--- a/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_publisher_params.h
@@ -91,6 +91,9 @@ public:
 
     process_noise_covariance = fuse_core::Vector8d(process_noise_diagonal.data()).asDiagonal();
 
+    nh.param("scale_process_noise", scale_process_noise, scale_process_noise);
+    nh.param("velocity_norm_min", velocity_norm_min, velocity_norm_min);
+
     double tf_cache_time_double = tf_cache_time.toSec();
     nh.getParam("tf_cache_time", tf_cache_time_double);
     tf_cache_time.fromSec(tf_cache_time_double);
@@ -134,6 +137,8 @@ public:
   bool predict_to_current_time { false };
   double publish_frequency { 10.0 };
   fuse_core::Matrix8d process_noise_covariance;   //!< Process noise covariance matrix
+  bool scale_process_noise{ false };
+  double velocity_norm_min{ 1e-3 };
   ros::Duration tf_cache_time { 10.0 };
   ros::Duration tf_timeout { 0.1 };
   int queue_size { 1 };

--- a/fuse_models/include/fuse_models/unicycle_2d.h
+++ b/fuse_models/include/fuse_models/unicycle_2d.h
@@ -162,6 +162,10 @@ protected:
   fuse_core::UUID device_id_;                      //!< The UUID of the device to be published
   fuse_core::TimestampManager timestamp_manager_;  //!< Tracks timestamps and previously created motion model segments
   fuse_core::Matrix8d process_noise_covariance_;   //!< Process noise covariance matrix
+  bool scale_process_noise_{ false };              //!< Whether to scale the process noise covariance pose by the norm
+                                                   //!< of the current state twist
+  double velocity_norm_min_{ 1e-3 };               //!< The minimum velocity/twist norm allowed when scaling the
+                                                   //!< process noise covariance
   StateHistory state_history_;                     //!< History of optimized graph pose estimates
 };
 

--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -33,6 +33,7 @@
  */
 #include <fuse_models/odometry_2d_publisher.h>
 #include <fuse_models/unicycle_2d_predict.h>
+#include <fuse_models/common/sensor_proc.h>
 
 #include <fuse_core/async_publisher.h>
 #include <fuse_core/eigen.h>
@@ -330,7 +331,15 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
 
       const Eigen::Matrix<double, 6, 6> J = jacobian.topLeftCorner<6, 6>();
       covariance = J * covariance * J.transpose();
-      covariance.noalias() += dt * params_.process_noise_covariance.topLeftCorner<6, 6>();
+
+      auto process_noise_covariance = params_.process_noise_covariance;
+      if (params_.scale_process_noise)
+      {
+        common::scaleProcessNoiseCovariance(process_noise_covariance, velocity_linear,
+                                            odom_output_.twist.twist.angular.z, params_.velocity_norm_min);
+      }
+
+      covariance.noalias() += dt * process_noise_covariance.topLeftCorner<6, 6>();
 
       odom_output_.pose.covariance[0] = covariance(0, 0);
       odom_output_.pose.covariance[1] = covariance(0, 1);


### PR DESCRIPTION
This scales the process noise covariance pose by the norm of the current
state velocity.

A new parameter `velocity_norm_min` is added, that prevents the process
noise scaling from setting the pose components to zero or a very small
value that could lead to NaN or a rank deficient Jacobian in the problem
solved, due to an ill-condition covariance for the process noise.