### PR TITLE
[CORE-15415] Support yaml struct

### DIFF
--- a/fuse_optimizers/CMakeLists.txt
+++ b/fuse_optimizers/CMakeLists.txt
@@ -154,4 +154,27 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD 14
       CXX_STANDARD_REQUIRED YES
   )
+
+  # Optimizer Tests
+  add_rostest_gtest(test_optimizer
+    test/optimizer.test
+    test/test_optimizer.cpp
+  )
+  add_dependencies(test_optimizer
+    ${catkin_EXPORTED_TARGETS}
+  )
+  target_include_directories(test_optimizer
+    PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+  )
+  target_link_libraries(test_optimizer
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+  )
+  set_target_properties(test_optimizer
+    PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED YES
+  )
 endif()

--- a/fuse_optimizers/package.xml
+++ b/fuse_optimizers/package.xml
@@ -23,6 +23,7 @@
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>std_srvs</depend>
+  <test_depend>fuse_models</test_depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
 

--- a/fuse_optimizers/src/optimizer.cpp
+++ b/fuse_optimizers/src/optimizer.cpp
@@ -102,36 +102,64 @@ void Optimizer::loadMotionModels()
     return;
   }
   // Validate the parameter server values
-  XmlRpc::XmlRpcValue motion_model_list;
-  private_node_handle_.getParam("motion_models", motion_model_list);
-  if (motion_model_list.getType() != XmlRpc::XmlRpcValue::TypeArray)
+  XmlRpc::XmlRpcValue motion_models;
+  private_node_handle_.getParam("motion_models", motion_models);
+  if (motion_models.getType() == XmlRpc::XmlRpcValue::TypeArray)
   {
-    throw std::invalid_argument("The 'motion_models' parameter should be a list of the form: "
-                                "-{name: string, type: string}");
-  }
-  // Validate all of the parameters before we attempt to create any plugin instances
-  for (int32_t motion_model_index = 0; motion_model_index < motion_model_list.size(); ++motion_model_index)
-  {
-    // Validate the parameter server values
-    if ( (motion_model_list[motion_model_index].getType() != XmlRpc::XmlRpcValue::TypeStruct)
-      || (!motion_model_list[motion_model_index].hasMember("name"))
-      || (!motion_model_list[motion_model_index].hasMember("type")))
+    // Validate all of the parameters before we attempt to create any plugin instances
+    for (int32_t motion_model_index = 0; motion_model_index < motion_models.size(); ++motion_model_index)
     {
-      throw std::invalid_argument("The 'motion_models' parameter should be a list of the form: "
-                                  "-{name: string, type: string}");
+      // Validate the parameter server values
+      if ( (motion_models[motion_model_index].getType() != XmlRpc::XmlRpcValue::TypeStruct)
+        || (!motion_models[motion_model_index].hasMember("name"))
+        || (!motion_models[motion_model_index].hasMember("type")))
+      {
+        throw std::invalid_argument("The 'motion_models' parameter should be a list of the form: "
+                                    "-{name: string, type: string}");
+      }
+    }
+    for (int32_t motion_model_index = 0; motion_model_index < motion_models.size(); ++motion_model_index)
+    {
+      // Get the setting we need from the parameter server
+      std::string motion_model_name = static_cast<std::string>(motion_models[motion_model_index]["name"]);
+      std::string motion_model_type = static_cast<std::string>(motion_models[motion_model_index]["type"]);
+      // Create a motion model object using pluginlib. This will throw if the plugin name is not found.
+      auto motion_model = motion_model_loader_.createUniqueInstance(motion_model_type);
+      // Initialize the publisher
+      motion_model->initialize(motion_model_name);
+      // Store the publisher in a member variable for use later
+      motion_models_.emplace(motion_model_name, std::move(motion_model));
     }
   }
-  for (int32_t motion_model_index = 0; motion_model_index < motion_model_list.size(); ++motion_model_index)
+  else if (motion_models.getType() == XmlRpc::XmlRpcValue::TypeStruct)
   {
-    // Get the setting we need from the parameter server
-    std::string motion_model_name = static_cast<std::string>(motion_model_list[motion_model_index]["name"]);
-    std::string motion_model_type = static_cast<std::string>(motion_model_list[motion_model_index]["type"]);
-    // Create a motion model object using pluginlib. This will throw if the plugin name is not found.
-    auto motion_model = motion_model_loader_.createUniqueInstance(motion_model_type);
-    // Initialize the publisher
-    motion_model->initialize(motion_model_name);
-    // Store the publisher in a member variable for use later
-    motion_models_.emplace(motion_model_name, std::move(motion_model));
+    // Validate all of the parameters before we attempt to create any plugin instances
+    for (const auto& motion_model_entry : motion_models)
+    {
+      if ( (motion_model_entry.second.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+        || (!motion_model_entry.second.hasMember("type")))
+      {
+        throw std::invalid_argument("The 'motion_models' parameter should be a struct of the form: "
+                                    "{string: {type: string}}");
+      }
+    }
+    for (const auto& motion_model_entry : motion_models)
+    {
+      // Get the setting we need from the parameter server
+      std::string motion_model_name = static_cast<std::string>(motion_model_entry.first);
+      std::string motion_model_type = static_cast<std::string>(motion_model_entry.second["type"]);
+      // Create a motion model object using pluginlib. This will throw if the plugin name is not found.
+      auto motion_model = motion_model_loader_.createUniqueInstance(motion_model_type);
+      // Initialize the publisher
+      motion_model->initialize(motion_model_name);
+      // Store the publisher in a member variable for use later
+      motion_models_.emplace(motion_model_name, std::move(motion_model));
+    }
+  }
+  else
+  {
+    throw std::invalid_argument("The 'motion_models' parameter should be a list of the form: "
+                                "-{name: string, type: string} or a struct of the form: {string: {type: string}}");
   }
 
   diagnostic_updater_.force_update();
@@ -145,55 +173,105 @@ void Optimizer::loadSensorModels()
     return;
   }
   // Validate the parameter server values
-  XmlRpc::XmlRpcValue sensor_model_list;
-  private_node_handle_.getParam("sensor_models", sensor_model_list);
-  if (sensor_model_list.getType() != XmlRpc::XmlRpcValue::TypeArray)
+  XmlRpc::XmlRpcValue sensor_models;
+  private_node_handle_.getParam("sensor_models", sensor_models);
+  if (sensor_models.getType() == XmlRpc::XmlRpcValue::TypeArray)
   {
-    throw std::invalid_argument("The 'sensor_models' parameter should be a list of the form: "
-                                "-{name: string, type: string, motion_models: [name1, name2, ...]}");
-  }
-  // Validate all of the parameters before we attempt to create any plugin instances
-  for (int32_t sensor_index = 0; sensor_index < sensor_model_list.size(); ++sensor_index)
-  {
-    // Validate the parameter server values
-    if ( (sensor_model_list[sensor_index].getType() != XmlRpc::XmlRpcValue::TypeStruct)
-      || (!sensor_model_list[sensor_index].hasMember("name"))
-      || (!sensor_model_list[sensor_index].hasMember("type")))
+    // Validate all of the parameters before we attempt to create any plugin instances
+    for (int32_t sensor_model_index = 0; sensor_model_index < sensor_models.size(); ++sensor_model_index)
     {
-      throw std::invalid_argument("The 'sensor_models' parameter should be a list of the form: "
-                                  "-{name: string, type: string, motion_models: [name1, name2, ...]}");
-    }
-  }
-  for (int32_t sensor_index = 0; sensor_index < sensor_model_list.size(); ++sensor_index)
-  {
-    // Get the setting we need from the parameter server
-    std::string sensor_name = static_cast<std::string>(sensor_model_list[sensor_index]["name"]);
-    std::string sensor_type = static_cast<std::string>(sensor_model_list[sensor_index]["type"]);
-    // Create a sensor object using pluginlib. This will throw if the plugin name is not found.
-    auto sensor_model = sensor_model_loader_.createUniqueInstance(sensor_type);
-    // Initialize the sensor
-    sensor_model->initialize(
-      sensor_name,
-      std::bind(&Optimizer::injectCallback, this, sensor_name, std::placeholders::_1));
-    // Store the sensor in a member variable for use later
-    sensor_models_.emplace(sensor_name, std::move(sensor_model));
-    // Parse out the list of associated motion models, if any
-    if ( (sensor_model_list[sensor_index].hasMember("motion_models"))
-      && (sensor_model_list[sensor_index]["motion_models"].getType() == XmlRpc::XmlRpcValue::TypeArray))
-    {
-      XmlRpc::XmlRpcValue motion_model_list = sensor_model_list[sensor_index]["motion_models"];
-      for (int32_t motion_model_index = 0; motion_model_index < motion_model_list.size(); ++motion_model_index)
+      // Validate the parameter server values
+      if ( (sensor_models[sensor_model_index].getType() != XmlRpc::XmlRpcValue::TypeStruct)
+        || (!sensor_models[sensor_model_index].hasMember("name"))
+        || (!sensor_models[sensor_model_index].hasMember("type")))
       {
-        std::string motion_model_name = static_cast<std::string>(motion_model_list[motion_model_index]);
-        associated_motion_models_[sensor_name].push_back(motion_model_name);
-        if (motion_models_.find(motion_model_name) == motion_models_.end())
+        throw std::invalid_argument("The 'sensor_models' parameter should be a list of the form: "
+                                    "-{name: string, type: string, motion_models: [name1, name2, ...]}");
+      }
+    }
+    for (int32_t sensor_model_index = 0; sensor_model_index < sensor_models.size(); ++sensor_model_index)
+    {
+      // Get the setting we need from the parameter server
+      std::string sensor_name = static_cast<std::string>(sensor_models[sensor_model_index]["name"]);
+      std::string sensor_type = static_cast<std::string>(sensor_models[sensor_model_index]["type"]);
+      // Create a sensor object using pluginlib. This will throw if the plugin name is not found.
+      auto sensor_model = sensor_model_loader_.createUniqueInstance(sensor_type);
+      // Initialize the sensor
+      sensor_model->initialize(
+        sensor_name,
+        std::bind(&Optimizer::injectCallback, this, sensor_name, std::placeholders::_1));
+      // Store the sensor in a member variable for use later
+      sensor_models_.emplace(sensor_name, std::move(sensor_model));
+      // Parse out the list of associated motion models, if any
+      if ( (sensor_models[sensor_model_index].hasMember("motion_models"))
+        && (sensor_models[sensor_model_index]["motion_models"].getType() == XmlRpc::XmlRpcValue::TypeArray))
+      {
+        XmlRpc::XmlRpcValue motion_model_list = sensor_models[sensor_model_index]["motion_models"];
+        for (int32_t motion_model_index = 0; motion_model_index < motion_model_list.size(); ++motion_model_index)
         {
-          ROS_WARN_STREAM("Sensor model '" << sensor_name << "' is configured to use motion model '" <<
-                          motion_model_name << "', but no motion model with that name currently exists. This is " <<
-                          "likely a configuration error.");
+          std::string motion_model_name = static_cast<std::string>(motion_model_list[motion_model_index]);
+          associated_motion_models_[sensor_name].push_back(motion_model_name);
+          if (motion_models_.find(motion_model_name) == motion_models_.end())
+          {
+            ROS_WARN_STREAM("Sensor model '" << sensor_name << "' is configured to use motion model '" <<
+                            motion_model_name << "', but no motion model with that name currently exists. This is " <<
+                            "likely a configuration error.");
+          }
         }
       }
     }
+  }
+  else if (sensor_models.getType() == XmlRpc::XmlRpcValue::TypeStruct)
+  {
+    // Validate all of the parameters before we attempt to create any plugin instances
+    for (const auto& sensor_model_entry : sensor_models)
+    {
+      // Validate the parameter server values
+      if ( (sensor_model_entry.second.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+        || (!sensor_model_entry.second.hasMember("type")))
+      {
+        throw std::invalid_argument("The 'sensor_models' parameter should be a struct of the form: "
+                                    "{string: {type: string, motion_models: [name1, name2, ...]}}");
+      }
+    }
+    for (const auto& sensor_model_entry : sensor_models)
+    {
+      // Get the setting we need from the parameter server
+      std::string sensor_name = static_cast<std::string>(sensor_model_entry.first);
+      std::string sensor_type = static_cast<std::string>(sensor_model_entry.second["type"]);
+      // Create a sensor object using pluginlib. This will throw if the plugin name is not found.
+      auto sensor_model = sensor_model_loader_.createUniqueInstance(sensor_type);
+      // Initialize the sensor
+      sensor_model->initialize(
+        sensor_name,
+        std::bind(&Optimizer::injectCallback, this, sensor_name, std::placeholders::_1));
+      // Store the sensor in a member variable for use later
+      sensor_models_.emplace(sensor_name, std::move(sensor_model));
+      // Parse out the list of associated motion models, if any
+      if ( (sensor_model_entry.second.hasMember("motion_models"))
+        && (sensor_model_entry.second["motion_models"].getType() == XmlRpc::XmlRpcValue::TypeArray))
+      {
+        XmlRpc::XmlRpcValue motion_model_list = sensor_model_entry.second["motion_models"];
+        for (int32_t motion_model_index = 0; motion_model_index < motion_model_list.size(); ++motion_model_index)
+        {
+          std::string motion_model_name = static_cast<std::string>(motion_model_list[motion_model_index]);
+          associated_motion_models_[sensor_name].push_back(motion_model_name);
+          if (motion_models_.find(motion_model_name) == motion_models_.end())
+          {
+            ROS_WARN_STREAM("Sensor model '" << sensor_name << "' is configured to use motion model '" <<
+                            motion_model_name << "', but no motion model with that name currently exists. This is " <<
+                            "likely a configuration error.");
+          }
+        }
+      }
+    }
+  }
+  else
+  {
+    throw std::invalid_argument("The 'sensor_models' parameter should be a list of the form: "
+                                "-{name: string, type: string, motion_models: [name1, name2, ...]} "
+                                "or a struct of the form: "
+                                "{string: {type: string, motion_models: [name1, name2, ...]}}");
   }
 
   diagnostic_updater_.force_update();
@@ -207,37 +285,65 @@ void Optimizer::loadPublishers()
     return;
   }
   // Validate the parameter server values
-  XmlRpc::XmlRpcValue publishers_list;
-  private_node_handle_.getParam("publishers", publishers_list);
-  if (publishers_list.getType() != XmlRpc::XmlRpcValue::TypeArray)
+  XmlRpc::XmlRpcValue publishers;
+  private_node_handle_.getParam("publishers", publishers);
+  if (publishers.getType() == XmlRpc::XmlRpcValue::TypeArray)
   {
-    throw std::invalid_argument("The 'publishers' parameter should be a list of the form: "
-                                "-{name: string, type: string}");
-  }
-  // Validate all of the parameters before we attempt to create any plugin instances
-  for (int32_t publisher_index = 0; publisher_index < publishers_list.size(); ++publisher_index)
-  {
-    // Validate the parameter server values
-    if ( (publishers_list[publisher_index].getType() != XmlRpc::XmlRpcValue::TypeStruct)
-      || (!publishers_list[publisher_index].hasMember("name"))
-      || (!publishers_list[publisher_index].hasMember("type")))
+    // Validate all of the parameters before we attempt to create any plugin instances
+    for (int32_t publisher_index = 0; publisher_index < publishers.size(); ++publisher_index)
     {
-      std::cout << "'publishers' parameter is not a list" << std::endl;
-      throw std::invalid_argument("The 'publishers' parameter should be a list of the form: "
-                                  "-{name: string, type: string}");
+      // Validate the parameter server values
+      if ( (publishers[publisher_index].getType() != XmlRpc::XmlRpcValue::TypeStruct)
+        || (!publishers[publisher_index].hasMember("name"))
+        || (!publishers[publisher_index].hasMember("type")))
+      {
+        throw std::invalid_argument("The 'publishers' parameter should be a list of the form: "
+                                    "-{name: string, type: string}");
+      }
+    }
+    for (int32_t publisher_index = 0; publisher_index < publishers.size(); ++publisher_index)
+    {
+      // Get the setting we need from the parameter server
+      std::string publisher_name = static_cast<std::string>(publishers[publisher_index]["name"]);
+      std::string publisher_type = static_cast<std::string>(publishers[publisher_index]["type"]);
+      // Create a Publisher object using pluginlib. This will throw if the plugin name is not found.
+      auto publisher = publisher_loader_.createUniqueInstance(publisher_type);
+      // Initialize the publisher
+      publisher->initialize(publisher_name);
+      // Store the publisher in a member variable for use later
+      publishers_.emplace(publisher_name, std::move(publisher));
     }
   }
-  for (int32_t publisher_index = 0; publisher_index < publishers_list.size(); ++publisher_index)
+  else if (publishers.getType() == XmlRpc::XmlRpcValue::TypeStruct)
   {
-    // Get the setting we need from the parameter server
-    std::string publisher_name = static_cast<std::string>(publishers_list[publisher_index]["name"]);
-    std::string publisher_type = static_cast<std::string>(publishers_list[publisher_index]["type"]);
-    // Create a Publisher object using pluginlib. This will throw if the plugin name is not found.
-    auto publisher = publisher_loader_.createUniqueInstance(publisher_type);
-    // Initialize the publisher
-    publisher->initialize(publisher_name);
-    // Store the publisher in a member variable for use later
-    publishers_.emplace(publisher_name, std::move(publisher));
+    // Validate all of the parameters before we attempt to create any plugin instances
+    for (const auto& publisher_entry : publishers)
+    {
+      // Validate the parameter server values
+      if ( (publisher_entry.second.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+        || (!publisher_entry.second.hasMember("type")))
+      {
+        throw std::invalid_argument("The 'publishers' parameter should be a struct of the form: "
+                                    "{string: {type: string}}");
+      }
+    }
+    for (const auto& publisher_entry : publishers)
+    {
+      // Get the setting we need from the parameter server
+      std::string publisher_name = static_cast<std::string>(publisher_entry.first);
+      std::string publisher_type = static_cast<std::string>(publisher_entry.second["type"]);
+      // Create a Publisher object using pluginlib. This will throw if the plugin name is not found.
+      auto publisher = publisher_loader_.createUniqueInstance(publisher_type);
+      // Initialize the publisher
+      publisher->initialize(publisher_name);
+      // Store the publisher in a member variable for use later
+      publishers_.emplace(publisher_name, std::move(publisher));
+    }
+  }
+  else
+  {
+    throw std::invalid_argument("The 'publishers' parameter should be a list of the form: "
+                                "-{name: string, type: string} or a struct of the form: {string: {type: string}}");
   }
 
   diagnostic_updater_.force_update();

--- a/fuse_optimizers/test/common_robot_config.yaml
+++ b/fuse_optimizers/test/common_robot_config.yaml
@@ -1,0 +1,36 @@
+motion_models:
+  unicycle_2d:
+    type: fuse_models::Unicycle2D
+
+sensor_models:
+  unicycle_2d_ignition:
+    type: fuse_models::Unicycle2DIgnition
+    motion_models: ['unicycle_2d']
+  wheel_odometry:
+    type: fuse_models::Odometry2D
+    motion_models: ['unicycle_2d']
+  laser_localization:
+    type: fuse_models::Odometry2D
+    motion_models: ['unicycle_2d']
+
+publishers:
+  odometry_publisher:
+    type: fuse_models::Odometry2DPublisher
+
+
+unicycle_2d:
+  process_noise_diagonal: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+
+unicycle_2d_ignition:
+  initial_sigma: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+  publish_on_startup: false
+
+wheel_odometry:
+  topic: odom
+  differential: true
+  twist_target_frame: base_link
+
+laser_localization:
+  topic: pose
+  pose_target_frame: map
+  twist_target_frame: base_link

--- a/fuse_optimizers/test/noisy_motion_model_config.yaml
+++ b/fuse_optimizers/test/noisy_motion_model_config.yaml
@@ -1,0 +1,7 @@
+motion_models:
+  noisy_unicycle_2d:
+    type: fuse_models::Unicycle2D
+
+
+noisy_unicycle_2d:
+  process_noise_diagonal: [1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1]

--- a/fuse_optimizers/test/optimizer.test
+++ b/fuse_optimizers/test/optimizer.test
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<launch>
+  <test test-name="Optimizer" pkg="fuse_optimizers" type="test_optimizer">
+    <rosparam file="$(find fuse_optimizers)/test/common_robot_config.yaml" command="load"/>
+    <rosparam file="$(find fuse_optimizers)/test/robot_with_imu_config.yaml" command="load"/>
+    <rosparam file="$(find fuse_optimizers)/test/noisy_motion_model_config.yaml" command="load"/>
+    <rosparam file="$(find fuse_optimizers)/test/serialized_publisher_config.yaml" command="load"/>
+  </test>
+</launch>

--- a/fuse_optimizers/test/robot_with_imu_config.yaml
+++ b/fuse_optimizers/test/robot_with_imu_config.yaml
@@ -1,0 +1,12 @@
+motion_models:
+  unicycle_2d:
+    type: fuse_models::Unicycle2D
+
+sensor_models:
+  imu:
+    type: fuse_models::Imu2D
+    motion_models: ['unicycle_2d']
+
+
+imu:
+  topic: imu

--- a/fuse_optimizers/test/serialized_publisher_config.yaml
+++ b/fuse_optimizers/test/serialized_publisher_config.yaml
@@ -1,0 +1,3 @@
+publishers:
+  serialized_publisher:
+    type: fuse_publishers::SerializedPublisher

--- a/fuse_optimizers/test/test_optimizer.cpp
+++ b/fuse_optimizers/test/test_optimizer.cpp
@@ -1,0 +1,189 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <fuse_optimizers/optimizer.h>
+#include <fuse_graphs/hash_graph.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+#include <ros/ros.h>
+
+
+/**
+ * @brief Dummy optimizer that exposes the motion and sensor models, and the publishers, so we can check the expected
+ * ones are loaded.
+ */
+class DummyOptimizer : public fuse_optimizers::Optimizer
+{
+public:
+  SMART_PTR_DEFINITIONS(DummyOptimizer);
+
+  using MotionModelUniquePtr = fuse_optimizers::Optimizer::MotionModelUniquePtr;
+  using SensorModelUniquePtr = fuse_optimizers::Optimizer::SensorModelUniquePtr;
+  using PublisherUniquePtr = fuse_optimizers::Optimizer::PublisherUniquePtr;
+
+  DummyOptimizer(fuse_core::Graph::UniquePtr graph, const ros::NodeHandle& node_handle = ros::NodeHandle(),
+                 const ros::NodeHandle& private_node_handle = ros::NodeHandle("~"))
+    : fuse_optimizers::Optimizer(std::move(graph), node_handle, private_node_handle)
+  {
+  }
+
+  const MotionModels& getMotionModels() const
+  {
+    return motion_models_;
+  }
+
+  const SensorModels& getSensorModels() const
+  {
+    return sensor_models_;
+  }
+
+  const Publishers& getPublishers() const
+  {
+    return publishers_;
+  }
+
+  void transactionCallback(
+      const std::string& sensor_name,
+      fuse_core::Transaction::SharedPtr transaction) override
+  {
+  }
+};
+
+/**
+ * @brief Helper function to print the elements of std::vector<T> objects
+ *
+ * @param[in, out] os An output stream
+ * @param[in] v A vector to print into the stream
+ * @return The output stream with the vector printed into it
+ */
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const std::vector<T>& v)
+{
+  os << '[';
+
+  if (!v.empty())
+  {
+    std::copy(v.begin(), v.end() - 1, std::ostream_iterator<T>(os, ", "));
+    os << v.back();
+  }
+
+  os << ']';
+
+  return os;
+}
+
+TEST(Optimizer, Constructor)
+{
+  // Create dummy optimizer:
+  DummyOptimizer optimizer(fuse_graphs::HashGraph::make_unique());
+
+  // Check the motion and sensor models, and publishers were loaded:
+  const auto& motion_models = optimizer.getMotionModels();
+  const auto& sensor_models = optimizer.getSensorModels();
+  const auto& publishers = optimizer.getPublishers();
+
+  EXPECT_FALSE(motion_models.empty());
+  EXPECT_FALSE(sensor_models.empty());
+  EXPECT_FALSE(publishers.empty());
+
+  // Check the expected motion and sensor models, and publisher were loaded:
+  std::vector<std::string> expected_motion_models = { "unicycle_2d", "noisy_unicycle_2d" } ;
+  std::vector<std::string> expected_sensor_models = { "unicycle_2d_ignition", "wheel_odometry",
+                                                           "laser_localization", "imu" };
+  std::vector<std::string> expected_publishers = { "odometry_publisher", "serialized_publisher" };
+
+  // Sort them so we can use std::set_symmetric_difference:
+  std::sort(expected_motion_models.begin(), expected_motion_models.end());
+  std::sort(expected_sensor_models.begin(), expected_sensor_models.end());
+  std::sort(expected_publishers.begin(), expected_publishers.end());
+
+  // Retrieve the keys for all motion and sensor models, and publishers:
+  const auto get_key = [](const auto& pair) { return pair.first; };
+
+  std::vector<std::string> actual_motion_models;
+  std::transform(motion_models.begin(), motion_models.end(), std::back_inserter(actual_motion_models), get_key);
+
+  std::vector<std::string> actual_sensor_models;
+  std::transform(sensor_models.begin(), sensor_models.end(), std::back_inserter(actual_sensor_models), get_key);
+
+  std::vector<std::string> actual_publishers;
+  std::transform(publishers.begin(), publishers.end(), std::back_inserter(actual_publishers), get_key);
+
+  // Sort them so we can use std::set_symmetric_difference:
+  std::sort(actual_motion_models.begin(), actual_motion_models.end());
+  std::sort(actual_sensor_models.begin(), actual_sensor_models.end());
+  std::sort(actual_publishers.begin(), actual_publishers.end());
+
+  // Compute the symmetric difference between the expected and actual motion and sensor models, and publishers:
+  std::vector<std::string> difference_motion_models;
+  std::set_symmetric_difference(expected_motion_models.begin(), expected_motion_models.end(),
+                                actual_motion_models.begin(), actual_motion_models.end(),
+                                std::back_inserter(difference_motion_models));
+
+  std::vector<std::string> difference_sensor_models;
+  std::set_symmetric_difference(expected_sensor_models.begin(), expected_sensor_models.end(),
+                                actual_sensor_models.begin(), actual_sensor_models.end(),
+                                std::back_inserter(difference_sensor_models));
+
+  std::vector<std::string> difference_publishers;
+  std::set_symmetric_difference(expected_publishers.begin(), expected_publishers.end(), actual_publishers.begin(),
+                                actual_publishers.end(), std::back_inserter(difference_publishers));
+
+  // Check the symmetric difference is empty, i.e. the actual motion and sensor models, and publishers are the same as
+  // the expected ones:
+  EXPECT_TRUE(difference_motion_models.empty())
+      << "Actual: " << actual_motion_models << "\nExpected: " << expected_motion_models
+      << "\nDifference: " << difference_motion_models;
+  EXPECT_TRUE(difference_sensor_models.empty())
+      << "Actual: " << actual_sensor_models << "\nExpected: " << expected_sensor_models
+      << "\nDifference: " << difference_sensor_models;
+  EXPECT_TRUE(difference_publishers.empty())
+      << "Actual: " << actual_publishers << "\nExpected: " << expected_publishers
+      << "\nDifference: " << difference_publishers;
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "test_optimizer");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}


### PR DESCRIPTION
fixes CORE-15415

This allows to compound multiple YAML files that provide additional
models or publishers. This cannot be done with a list/array, because the
previous values get overwritten/lost.

There's an example in the new rostest provided with this PR.

I've sent this same change upstream in https://github.com/locusrobotics/fuse/pull/149