### PR TITLE
Get minimum_pose_relative_covariance_diagonal

### DIFF
--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -88,14 +88,10 @@ struct Odometry2DParams : public ParameterBase
       else
       {
         nh.getParam("independent", independent);
+        nh.getParam("use_twist_covariance", use_twist_covariance);
 
-        if (!independent)
-        {
-          nh.getParam("use_twist_covariance", use_twist_covariance);
-
-          minimum_pose_relative_covariance =
-              fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
-        }
+        minimum_pose_relative_covariance =
+            fuse_core::getCovarianceDiagonalParam<3>(nh, "minimum_pose_relative_covariance_diagonal", 0.0);
       }
 
       pose_loss = fuse_core::loadLossConfig(nh, "pose_loss");


### PR DESCRIPTION
Regardless of the value of `independent`, because the
`fuse_models::Odometry2D` sensor model checks for `use_twist_covariance`
before `independent`, and we could end up with an uninitialized
`minimum_pose_relative_covariance_diagonal`.