### PR TITLE
[CORE-15862] Fix Unicycle2DIgnition set_pose

### DIFF
--- a/fuse_core/src/timestamp_manager.cpp
+++ b/fuse_core/src/timestamp_manager.cpp
@@ -156,6 +156,11 @@ void TimestampManager::query(
     // Insert the last timestamp into the motion model history, but with no constraints. The last entry in the motion
     // model history will always contain no constraints.
     motion_model_history_.emplace(last_stamp, MotionModelSegment());
+
+    // Call the motion model generator so it inserts the last timestamp into its state history.
+    std::vector<Constraint::SharedPtr> constraints;
+    std::vector<Variable::SharedPtr> variables;
+    generator_(last_stamp, last_stamp, constraints, variables);
   }
   // Purge any old entries from the motion model history
   purgeHistory();

--- a/fuse_core/test/test_timestamp_manager.cpp
+++ b/fuse_core/test/test_timestamp_manager.cpp
@@ -542,7 +542,7 @@ TEST_F(TimestampManagerTestFixture, MultiSegment)
   ASSERT_EQ(0ul, generated_time_spans.size());
 }
 
-TEST_F(TimestampManagerTestFixture, MultiSegmentBeforBeginning)
+TEST_F(TimestampManagerTestFixture, MultiSegmentBeforeBeginning)
 {
   // Test:
   // Existing: |------111111112222222233333333-------> t

--- a/fuse_core/test/test_timestamp_manager.cpp
+++ b/fuse_core/test/test_timestamp_manager.cpp
@@ -112,9 +112,12 @@ TEST_F(TimestampManagerTestFixture, Empty)
   EXPECT_EQ(ros::Time(20, 0), *stamp_range_iter);
 
   // Verify the expected queries were performed
-  ASSERT_EQ(1ul, generated_time_spans.size());
+  // And additional time span is generated for the last stamp as beginning and ending stamp
+  ASSERT_EQ(2ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(10, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(20, 0), generated_time_spans[0].second);
+  EXPECT_EQ(ros::Time(20, 0), generated_time_spans[1].first);
+  EXPECT_EQ(generated_time_spans[1].first, generated_time_spans[1].second);
 }
 
 TEST_F(TimestampManagerTestFixture, Exceptions)
@@ -420,9 +423,12 @@ TEST_F(TimestampManagerTestFixture, AfterEndAligned)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  ASSERT_EQ(1ul, generated_time_spans.size());
+  // And additional time span is generated for the last stamp as beginning and ending stamp
+  ASSERT_EQ(2ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[0].second);
+  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[1].first);
+  EXPECT_EQ(generated_time_spans[1].first, generated_time_spans[1].second);
 }
 
 TEST_F(TimestampManagerTestFixture, AfterEndUnaligned)
@@ -455,11 +461,14 @@ TEST_F(TimestampManagerTestFixture, AfterEndUnaligned)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  ASSERT_EQ(2ul, generated_time_spans.size());
+  // And additional time span is generated for the last stamp as beginning and ending stamp
+  ASSERT_EQ(3ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(42, 0), generated_time_spans[0].second);
   EXPECT_EQ(ros::Time(42, 0), generated_time_spans[1].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[1].second);
+  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[2].first);
+  EXPECT_EQ(generated_time_spans[2].first, generated_time_spans[2].second);
 }
 
 TEST_F(TimestampManagerTestFixture, AfterEndOverlap)
@@ -492,13 +501,16 @@ TEST_F(TimestampManagerTestFixture, AfterEndOverlap)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  ASSERT_EQ(3ul, generated_time_spans.size());
+  // And additional time span is generated for the last stamp as beginning and ending stamp
+  ASSERT_EQ(4ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(30, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(35, 0), generated_time_spans[0].second);
   EXPECT_EQ(ros::Time(35, 0), generated_time_spans[1].first);
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[1].second);
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[2].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[2].second);
+  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[3].first);
+  EXPECT_EQ(generated_time_spans[3].first, generated_time_spans[3].second);
 }
 
 TEST_F(TimestampManagerTestFixture, MultiSegment)
@@ -591,9 +603,12 @@ TEST_F(TimestampManagerTestFixture, MultiSegmentPastEnd)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  ASSERT_EQ(1ul, generated_time_spans.size());
+  // And additional time span is generated for the last stamp as beginning and ending stamp
+  ASSERT_EQ(2ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[0].second);
+  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[1].first);
+  EXPECT_EQ(generated_time_spans[1].first, generated_time_spans[1].second);
 }
 
 TEST_F(TimestampManagerTestFixture, MultiSegmentPastBothEnds)
@@ -626,11 +641,14 @@ TEST_F(TimestampManagerTestFixture, MultiSegmentPastBothEnds)
   EXPECT_EQ(ros::Time(45, 0), *stamp_range_iter);
 
   // Verify the expected new motion model segments were generated
-  ASSERT_EQ(2ul, generated_time_spans.size());
+  // And additional time span is generated for the last stamp as beginning and ending stamp
+  ASSERT_EQ(3ul, generated_time_spans.size());
   EXPECT_EQ(ros::Time(5, 0), generated_time_spans[0].first);
   EXPECT_EQ(ros::Time(10, 0), generated_time_spans[0].second);
   EXPECT_EQ(ros::Time(40, 0), generated_time_spans[1].first);
   EXPECT_EQ(ros::Time(45, 0), generated_time_spans[1].second);
+  EXPECT_EQ(ros::Time(45, 0), generated_time_spans[2].first);
+  EXPECT_EQ(generated_time_spans[2].first, generated_time_spans[2].second);
 }
 
 TEST_F(TimestampManagerTestFixture, SplitBeginning)

--- a/fuse_models/include/fuse_models/unicycle_2d.h
+++ b/fuse_models/include/fuse_models/unicycle_2d.h
@@ -99,7 +99,7 @@ protected:
     fuse_core::UUID acc_linear_uuid;      //!< The uuid of the associated orientation variable
     tf2_2d::Transform pose;               //!< Map-frame pose
     tf2_2d::Vector2 velocity_linear;       //!< Body-frame linear velocity
-    double velocity_yaw;                  //!< Body-frame yaw velocity
+    double velocity_yaw{ 0.0 };           //!< Body-frame yaw velocity
     tf2_2d::Vector2 acceleration_linear;  //!< Body-frame linear acceleration
   };
   using StateHistory = std::map<ros::Time, StateHistoryElement>;

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -172,6 +172,8 @@ protected:
   std::mutex pending_transactions_mutex_;  //!< Synchronize modification of the pending_transactions_ container
   ros::Time start_time_;  //!< The timestamp of the first ignition sensor transaction
   bool started_;  //!< Flag indicating the optimizer is ready/has received a transaction from an ignition sensor
+  bool ignited_;  //!< Flag indicating the optimizer has received a transaction from an ignition sensor and it is queued
+                  //!< but not processed yet
   VariableStampIndex timestamp_tracking_;  //!< Object that tracks the timestamp associated with each variable
 
   // Ordering ROS objects with callbacks last


### PR DESCRIPTION
Sometimes the pose set with the `set_pose` service/topic using the `Unicycle2DIgnition` sensor model is ignored and the pose is set at a wrong, different location, typically at the origin of the map. This happens when the other sensor models include the `Odometry2D` using the `differential` mode.

This PR fixes several bugs that all contributed to this issue. In particular, it provides the following fixes:
1. Initialize `StateHistoryElement::velocity_yaw` which was used uninitialized: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/include/fuse_models/unicycle_2d.h#L102.
    - This impacted prediction in https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L177 because `base_state` is default constructed when the `beginning_stamp` isn't  in the state history: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L139-L150.
    - This produced incorrect predictions starting from the first state in the history.
    - And it also propagated into other states because the resulting predicted state is stored in the history: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L234-L235
    - The history and predicted states are used to set the initial value of the variables in the motion model constraint: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L206-L221, https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L246-L258, and these variables overwrite the ones from other constraints: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L83, https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_core/src/timestamp_manager.cpp#L163, so the optimization ends up using a bad initialization and cannot converge to the correct solution.

2. Process ignition transactions individually. This is important because the state history is only updated on graph updates: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L95
    - If the ignition transactions that contains the `set_pose` is processed together with some relative constraints from `differential` mode `Odometry2D` measurements (or equivalent), the state history cannot be updated.
    - Therefore, the state defaults to `0`/identity: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L139-L150, https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L177. That state is used for the previous pose variable in the relative constraints when they're connected to the variable of the `set_pose` absolute constraint.
    - The solution consists on processing the ignition transaction individually. This way the state history is updated to the `set_pose` value when it receives the new updated graph in: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L95

3. Call motion model generator with last stamp in order to update its state history.
    - When the history is empty or the `last_stamp` is newer than any stamp in the history, the motion model history is updated to include it in: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_core/src/timestamp_manager.cpp#L154-L159
    - However, the `Unicycle2D` motion model state history is not updated.
    - As a consequence, the `set_pose` doesn't get any entry into the state history and it cannot be updated when a new graph is received in: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L95
    - We can workaround this issue by calling the motion model `generator_` with the `last_stamp` as beginning and ending stamp. This will add a single entry because the predicted state will be the same as the beginning one: https://github.com/locusrobotics/fuse/blob/a1281b17a3c3b4c2b034a637ac1066615f167d7a/fuse_models/src/unicycle_2d.cpp#L234-L235. We don't need the constraint and variables generated, so we discard them. All we're looking for is an entry in the state history, so it can be updated when the graph is received.