### PR TITLE
[CORE-16008] Ignition

### DIFF
--- a/fuse_core/include/fuse_core/loss.h
+++ b/fuse_core/include/fuse_core/loss.h
@@ -172,7 +172,7 @@ public:
   SMART_PTR_ALIASES_ONLY(Loss);
 
   static constexpr ceres::Ownership Ownership =
-      ceres::Ownership::TAKE_OWNERSHIP;  //<! The ownership of the ceres::LossFunction* returned by lossFunction()
+      ceres::Ownership::TAKE_OWNERSHIP;  //!< The ownership of the ceres::LossFunction* returned by lossFunction()
 
   /**
    * @brief Default constructor

--- a/fuse_core/include/fuse_core/sensor_model.h
+++ b/fuse_core/include/fuse_core/sensor_model.h
@@ -132,6 +132,23 @@ public:
    */
   virtual void stop() {}
 
+  /**
+   * @brief Get whether this sensor model should be used as an ignition sensor or not
+   *
+   * The optimization will wait until a transaction is received from an ignition sensor. This is useful, for example,
+   * for providing an initial guess of the robot's position and orientation. Any transactions received before the
+   * ignition transaction will be deleted. If there is no ignition sensor, the optimization will start immediately.
+   *
+   * The sensor models default to not being ignition sensors. This can be overriden by ignition sensors, that could
+   * optionally be used as such or not at runtime based on a user given parameter.
+   *
+   * @return True if this sensor model should be used as an ignition sensor, false otherwise
+   */
+  virtual bool ignition() const
+  {
+    return false;
+  }
+
 protected:
   /**
    * @brief Default Constructor

--- a/fuse_loss/include/fuse_loss/arctan_loss.h
+++ b/fuse_loss/include/fuse_loss/arctan_loss.h
@@ -120,7 +120,7 @@ public:
   }
 
 private:
-  double a_{ 1.0 };  //<! ArctanLoss parameter 'a'. See Ceres documentation for more details
+  double a_{ 1.0 };  //!< ArctanLoss parameter 'a'. See Ceres documentation for more details
 
   // Allow Boost Serialization access to private methods
   friend class boost::serialization::access;

--- a/fuse_loss/include/fuse_loss/cauchy_loss.h
+++ b/fuse_loss/include/fuse_loss/cauchy_loss.h
@@ -120,7 +120,7 @@ public:
   }
 
 private:
-  double a_{ 1.0 };  //<! CauchyLoss parameter 'a'. See Ceres documentation for more details
+  double a_{ 1.0 };  //!< CauchyLoss parameter 'a'. See Ceres documentation for more details
 
   // Allow Boost Serialization access to private methods
   friend class boost::serialization::access;

--- a/fuse_loss/include/fuse_loss/dcs_loss.h
+++ b/fuse_loss/include/fuse_loss/dcs_loss.h
@@ -124,7 +124,7 @@ public:
   }
 
 private:
-  double a_{ 1.0 };  //<! DCSLoss parameter 'a'
+  double a_{ 1.0 };  //!< DCSLoss parameter 'a'
 
   // Allow Boost Serialization access to private methods
   friend class boost::serialization::access;

--- a/fuse_loss/include/fuse_loss/fair_loss.h
+++ b/fuse_loss/include/fuse_loss/fair_loss.h
@@ -124,7 +124,7 @@ public:
   }
 
 private:
-  double a_{ 1.0 };  //<! FairLoss parameter 'a'
+  double a_{ 1.0 };  //!< FairLoss parameter 'a'
 
   // Allow Boost Serialization access to private methods
   friend class boost::serialization::access;

--- a/fuse_loss/include/fuse_loss/geman_mcclure_loss.h
+++ b/fuse_loss/include/fuse_loss/geman_mcclure_loss.h
@@ -124,7 +124,7 @@ public:
   }
 
 private:
-  double a_{ 1.0 };  //<! GemanMcClureLoss parameter 'a'
+  double a_{ 1.0 };  //!< GemanMcClureLoss parameter 'a'
 
   // Allow Boost Serialization access to private methods
   friend class boost::serialization::access;

--- a/fuse_loss/include/fuse_loss/huber_loss.h
+++ b/fuse_loss/include/fuse_loss/huber_loss.h
@@ -120,7 +120,7 @@ public:
   }
 
 private:
-  double a_{ 1.0 };  //<! HuberLoss parameter 'a'. See Ceres documentation for more details
+  double a_{ 1.0 };  //!< HuberLoss parameter 'a'. See Ceres documentation for more details
 
   // Allow Boost Serialization access to private methods
   friend class boost::serialization::access;

--- a/fuse_loss/include/fuse_loss/scaled_loss.h
+++ b/fuse_loss/include/fuse_loss/scaled_loss.h
@@ -141,7 +141,7 @@ public:
   }
 
 private:
-  double a_{ 1.0 };  //<! ScaledLoss parameter 'a'. See Ceres documentation for more details
+  double a_{ 1.0 };  //!< ScaledLoss parameter 'a'. See Ceres documentation for more details
   std::shared_ptr<fuse_core::Loss> loss_{ nullptr };  //!< The loss function to scale
 
   // Allow Boost Serialization access to private methods

--- a/fuse_loss/include/fuse_loss/softlone_loss.h
+++ b/fuse_loss/include/fuse_loss/softlone_loss.h
@@ -120,7 +120,7 @@ public:
   }
 
 private:
-  double a_{ 1.0 };  //<! SoftLOneLoss parameter 'a'. See Ceres documentation for more details
+  double a_{ 1.0 };  //!< SoftLOneLoss parameter 'a'. See Ceres documentation for more details
 
   // Allow Boost Serialization access to private methods
   friend class boost::serialization::access;

--- a/fuse_loss/include/fuse_loss/tolerant_loss.h
+++ b/fuse_loss/include/fuse_loss/tolerant_loss.h
@@ -141,8 +141,8 @@ public:
   }
 
 private:
-  double a_{ 1.0 };  //<! TolerantLoss parameter 'a'. See Ceres documentation for more details
-  double b_{ 0.1 };  //<! TolerantLoss parameter 'b'. See Ceres documentation for more details
+  double a_{ 1.0 };  //!< TolerantLoss parameter 'a'. See Ceres documentation for more details
+  double b_{ 0.1 };  //!< TolerantLoss parameter 'b'. See Ceres documentation for more details
 
   // Allow Boost Serialization access to private methods
   friend class boost::serialization::access;

--- a/fuse_loss/include/fuse_loss/tukey_loss.h
+++ b/fuse_loss/include/fuse_loss/tukey_loss.h
@@ -120,7 +120,7 @@ public:
   }
 
 private:
-  double a_{ 1.0 };  //<! TukeyLoss parameter 'a'. See Ceres documentation for more details
+  double a_{ 1.0 };  //!< TukeyLoss parameter 'a'. See Ceres documentation for more details
 
   // Allow Boost Serialization access to private methods
   friend class boost::serialization::access;

--- a/fuse_loss/include/fuse_loss/welsch_loss.h
+++ b/fuse_loss/include/fuse_loss/welsch_loss.h
@@ -124,7 +124,7 @@ public:
   }
 
 private:
-  double a_{ 1.0 };  //<! WelschLoss parameter 'a'
+  double a_{ 1.0 };  //!< WelschLoss parameter 'a'
 
   // Allow Boost Serialization access to private methods
   friend class boost::serialization::access;

--- a/fuse_models/include/fuse_models/unicycle_2d_ignition.h
+++ b/fuse_models/include/fuse_models/unicycle_2d_ignition.h
@@ -114,6 +114,22 @@ public:
   void stop() override;
 
   /**
+   * @brief Get whether this sensor model should be used as an ignition sensor or not
+   *
+   * The optimization will wait until a transaction is received from an ignition sensor. This is useful, for example,
+   * for providing an initial guess of the robot's position and orientation. Any transactions received before the
+   * ignition transaction will be deleted. If there is no ignition sensor, the optimization will start immediately.
+   *
+   * By default this sensor model is an ignition sensor, but the user can disable that at runtime with a ROS parameter.
+   *
+   * @return True if this sensor model should be used as an ignition sensor, false otherwise
+   */
+  bool ignition() const override
+  {
+    return ignition_;
+  }
+
+  /**
    * @brief Triggers the publication of a new prior transaction at the supplied pose
    */
   void subscriberCallback(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& msg);
@@ -161,6 +177,8 @@ protected:
   bool initial_transaction_sent_;  //!< Flag indicating an initial transaction has been sent already
 
   fuse_core::UUID device_id_;  //!< The UUID of this device
+
+  bool ignition_{ true };  //!< Whether to use this sensor model as an ignition sensor or not
 
   ParameterType params_;  //!< Object containing all of the configuration parameters
 

--- a/fuse_models/src/unicycle_2d_ignition.cpp
+++ b/fuse_models/src/unicycle_2d_ignition.cpp
@@ -80,6 +80,7 @@ void Unicycle2DIgnition::onInit()
 {
   // Read settings from the parameter sever
   device_id_ = fuse_variables::loadDeviceId(private_node_handle_);
+  private_node_handle_.getParam("ignition", ignition_);
 
   params_.loadFromROS(private_node_handle_);
 

--- a/fuse_optimizers/CMakeLists.txt
+++ b/fuse_optimizers/CMakeLists.txt
@@ -187,6 +187,9 @@ if(CATKIN_ENABLE_TESTING)
     test/fixed_lag_ignition.test
     test/test_fixed_lag_ignition.cpp
   )
+  add_dependencies(test_fixed_lag_ignition
+    fixed_lag_smoother_node
+  )
   target_include_directories(test_fixed_lag_ignition
     PRIVATE
       include

--- a/fuse_optimizers/CMakeLists.txt
+++ b/fuse_optimizers/CMakeLists.txt
@@ -129,6 +129,7 @@ install(
 if(CATKIN_ENABLE_TESTING)
   find_package(roslint REQUIRED)
   find_package(rostest REQUIRED)
+  find_package(fuse_models REQUIRED)
   find_package(geometry_msgs REQUIRED)
   find_package(nav_msgs REQUIRED)
 
@@ -194,12 +195,14 @@ if(CATKIN_ENABLE_TESTING)
     PRIVATE
       include
       ${catkin_INCLUDE_DIRS}
+      ${fuse_models_INCLUDE_DIRS}
       ${geometry_msgs_INCLUDE_DIRS}
       ${nav_msgs_INCLUDE_DIRS}
       ${rostest_INCLUDE_DIRS}
   )
   target_link_libraries(test_fixed_lag_ignition
     ${catkin_LIBRARIES}
+    ${fuse_models_LIBRARIES}
     ${geometry_msgs_LIBRARIES}
     ${nav_msgs_LIBRARIES}
     ${rostest_LIBRARIES}

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer.h
@@ -66,12 +66,6 @@ namespace fuse_optimizers
  * waiting versus the time spent optimizing will approach zero as the problem size increases.
  *
  * Parameters:
- *  - ignition_sensors (string list, default: "") The optimization will wait until a transaction is received from one
- *                                                of these sensors. This is useful, for example, for providing an
- *                                                initial guess of the robot's position and orientation. Any
- *                                                transactions received before the ignition transaction will be deleted.
- *                                                Leaving the \p ignition_sensors list empty will cause the optimization
- *                                                to start immediately.
  *  - motion_models (struct array) The set of motion model plugins to load
  *    @code{.yaml}
  *    - name: string  (A unique name for this motion model)

--- a/fuse_optimizers/include/fuse_optimizers/batch_optimizer_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/batch_optimizer_params.h
@@ -56,13 +56,6 @@ struct BatchOptimizerParams
 {
 public:
   /**
-   * @brief The set of sensors whose transactions will trigger the optimizer thread to start running
-   *
-   * This is designed to keep the system idle until the origin constraint has been received.
-   */
-  std::vector<std::string> ignition_sensors;
-
-  /**
    * @brief The target duration for optimization cycles
    *
    * If an optimization takes longer than expected, an optimization cycle may be skipped. The optimization period
@@ -92,9 +85,6 @@ public:
   void loadFromROS(const ros::NodeHandle& nh)
   {
     // Read settings from the parameter server
-    nh.getParam("ignition_sensors", ignition_sensors);
-    std::sort(ignition_sensors.begin(), ignition_sensors.end());
-
     if (nh.hasParam("optimization_frequency"))
     {
       auto optimization_frequency =

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother.h
@@ -75,12 +75,6 @@ namespace fuse_optimizers
  *
  * Parameters:
  *  - lag_duration (float, default: 5.0) The duration of the smoothing window in seconds
- *  - ignition_sensors (string list, default: "") The optimization will wait until a transaction is received from one
- *                                                of these sensors. This is useful, for example, for providing an
- *                                                initial guess of the robot's position and orientation. Any
- *                                                transactions received before the ignition transaction will be deleted.
- *                                                Leaving the \p ignition_sensors list empty will cause the optimization
- *                                                to start immediately.
  *  - motion_models (struct array) The set of motion model plugins to load
  *    @code{.yaml}
  *    - name: string  (A unique name for this motion model)

--- a/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
+++ b/fuse_optimizers/include/fuse_optimizers/fixed_lag_smoother_params.h
@@ -56,13 +56,6 @@ struct FixedLagSmootherParams
 {
 public:
   /**
-   * @brief The set of sensors whose transactions will trigger the optimizer thread to start running
-   *
-   * This is designed to keep the system idle until the origin constraint has been received.
-   */
-  std::vector<std::string> ignition_sensors;
-
-  /**
    * @brief The duration of the smoothing window in seconds
    */
   ros::Duration lag_duration { 5.0 };
@@ -102,9 +95,6 @@ public:
   void loadFromROS(const ros::NodeHandle& nh)
   {
     // Read settings from the parameter server
-    nh.getParam("ignition_sensors", ignition_sensors);
-    std::sort(ignition_sensors.begin(), ignition_sensors.end());
-
     auto lag_duration_sec = fuse_core::getPositiveParam(nh, "lag_duration", lag_duration.toSec());
     lag_duration.fromSec(lag_duration_sec);
 

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -57,17 +57,6 @@ BatchOptimizer::BatchOptimizer(
 {
   params_.loadFromROS(private_node_handle);
 
-  // Warn about possible configuration errors
-  // TODO(swilliams) Move this warning to the Parameter loadFromROS() method once all parameters are loaded there.
-  for (const auto& sensor_model_name : params_.ignition_sensors)
-  {
-    if (sensor_models_.find(sensor_model_name) == sensor_models_.end())
-    {
-      ROS_WARN_STREAM("Sensor '" << sensor_model_name << "' is configured as an ignition sensor, but no sensor "
-                      "model with that name currently exists. This is likely a configuration error.");
-    }
-  }
-
   // Configure a timer to trigger optimizations
   optimize_timer_ = node_handle_.createTimer(
     ros::Duration(params_.optimization_period),
@@ -212,7 +201,7 @@ void BatchOptimizer::transactionCallback(
   if (!started_)
   {
     // Check if this transaction "starts" the system
-    if (std::binary_search(params_.ignition_sensors.begin(), params_.ignition_sensors.end(), sensor_name))
+    if (sensor_models_.at(sensor_name)->ignition())
     {
       started_ = true;
       start_time_ = transaction_time;

--- a/fuse_optimizers/src/fixed_lag_smoother.cpp
+++ b/fuse_optimizers/src/fixed_lag_smoother.cpp
@@ -90,17 +90,6 @@ FixedLagSmoother::FixedLagSmoother(
 {
   params_.loadFromROS(private_node_handle);
 
-  // Warn about possible configuration errors
-  // TODO(swilliams) Move this warning to the Parameter loadFromROS() method once all parameters are loaded there.
-  for (const auto& sensor_model_name : params_.ignition_sensors)
-  {
-    if (sensor_models_.find(sensor_model_name) == sensor_models_.end())
-    {
-      ROS_WARN_STREAM("Sensor '" << sensor_model_name << "' is configured as an ignition sensor, but no sensor "
-                      "model with that name currently exists. This is likely a configuration error.");
-    }
-  }
-
   // Test for auto-start
   autostart();
 
@@ -134,7 +123,8 @@ FixedLagSmoother::~FixedLagSmoother()
 
 void FixedLagSmoother::autostart()
 {
-  if (params_.ignition_sensors.empty())
+  if (std::none_of(sensor_models_.begin(), sensor_models_.end(),
+                   [](const auto& element) { return element.second->ignition(); }))  // NOLINT(whitespace/braces)
   {
     // No ignition sensors were provided. Auto-start.
     started_ = true;
@@ -288,7 +278,7 @@ void FixedLagSmoother::processQueue(fuse_core::Transaction& transaction)
 
     const auto transaction_rbegin = pending_transactions_.rbegin();
     auto& element = *transaction_rbegin;
-    if (!std::binary_search(params_.ignition_sensors.begin(), params_.ignition_sensors.end(), element.sensor_name))
+    if (!sensor_models_.at(element.sensor_name)->ignition())
     {
       // We just started, but the oldest transaction is not from an ignition sensor. We will still process the
       // transaction, but we do not enforce it is processed individually.
@@ -319,8 +309,7 @@ void FixedLagSmoother::processQueue(fuse_core::Transaction& transaction)
         const auto pending_ignition_transaction_iter =
             std::find_if(pending_transactions_.rbegin(), pending_transactions_.rend(),
                          [this](const auto& element) {  // NOLINT(whitespace/braces)
-                           return std::binary_search(params_.ignition_sensors.begin(), params_.ignition_sensors.end(),
-                                                     element.sensor_name);
+                           return sensor_models_.at(element.sensor_name)->ignition();
                          });  // NOLINT(whitespace/braces)
         if (pending_ignition_transaction_iter == pending_transactions_.rend())
         {
@@ -450,7 +439,7 @@ void FixedLagSmoother::transactionCallback(
     if (!started_)
     {
       // ...check if we should
-      if (std::binary_search(params_.ignition_sensors.begin(), params_.ignition_sensors.end(), sensor_name))
+      if (sensor_models_.at(sensor_name)->ignition())
       {
         started_ = true;
         ignited_ = true;

--- a/fuse_optimizers/test/fixed_lag_ignition.test
+++ b/fuse_optimizers/test/fixed_lag_ignition.test
@@ -1,12 +1,10 @@
-<?xml version="1.0"?>	
+<?xml version="1.0"?>
 <launch>
   <node name="fixed_lag" pkg="fuse_optimizers" type="fixed_lag_smoother_node" output="screen">
     <rosparam subst_value="true">
       optimization_frequency: 2.0
       transaction_timeout: 5.0
       lag_duration: 5.0
-
-      ignition_sensors: ['unicycle_ignition_sensor']
 
       solver_options:
         max_num_iterations: 0
@@ -22,27 +20,27 @@
         pose_sensor:
           type: fuse_models::Pose2D
           motion_models: [unicycle_motion_model]
-      
+
       publishers:
         odometry_publisher:
           type: fuse_models::Odometry2DPublisher
-      
+
       unicycle_motion_model:
         buffer_length: 5.0
         process_noise_diagonal: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
-      
+
       unicycle_ignition_sensor:
         publish_on_startup: false
         initial_state: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
         initial_sigma: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
-      
+
       pose_sensor:
         differential: true
         topic: relative_pose
         target_frame: base_link
         position_dimensions: ['x', 'y']
         orientation_dimensions: ['yaw']
-      
+
       odometry_publisher:
         topic: odom
         world_frame_id: map

--- a/fuse_viz/include/fuse_viz/mapped_covariance_visual.h
+++ b/fuse_viz/include/fuse_viz/mapped_covariance_visual.h
@@ -225,14 +225,14 @@ private:
   Ogre::SceneNode* orientation_root_node_;
   Ogre::SceneNode* orientation_offset_node_[kNumOriShapes];
 
-  rviz::Shape* position_shape_;                    ///< Ellipse used for the position covariance
-  rviz::Shape* orientation_shape_[kNumOriShapes];  ///< Cylinders used for the orientation covariance
+  rviz::Shape* position_shape_;                    //!< Ellipse used for the position covariance
+  rviz::Shape* orientation_shape_[kNumOriShapes];  //!< Cylinders used for the orientation covariance
 
   bool local_rotation_;
 
   bool pose_2d_;
 
-  bool orientation_visible_;  ///< If the orientation component is visible.
+  bool orientation_visible_;  //!< If the orientation component is visible.
 
   Ogre::Vector3 current_ori_scale_[kNumOriShapes];
   float current_ori_scale_factor_;


### PR DESCRIPTION
This PR removes the `ignition_sensors` list param and replaces it with an `ignition` ROS param field for the `fuse_models::Unicycle2DIgnition` sensor model. It also adds a `virtual bool ignition() const` method fo the base `SensorModel` class, so the `fuse_optimizer` nodes can rely on that to implement the ignition logic.

Some minor cleanup changes are also included in this PR.

Upstream PR: https://github.com/locusrobotics/fuse/pull/163