### PR TITLE
[CORE-16060] Fix throttle period

### DIFF
--- a/fuse_models/include/fuse_models/common/throttled_callback.h
+++ b/fuse_models/include/fuse_models/common/throttled_callback.h
@@ -135,7 +135,11 @@ public:
     const auto now = ros::Time::now();
     if (!last_called_time_.isValid() || now - last_called_time_ > throttle_period_)
     {
-      keep_callback_(message);
+      if (keep_callback_)
+      {
+        keep_callback_(message);
+      }
+
       last_called_time_ = now;
     }
     else if (drop_callback_)

--- a/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
@@ -69,9 +69,7 @@ struct Acceleration2DParams : public ParameterBase
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
 
-      double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
-      throttle_period.fromSec(throttle_period_double);
+      throttle_period.fromSec(fuse_core::getPositiveParam(nh, "throttle_period", throttle_period.toSec(), false));
 
       fuse_core::getParamRequired(nh, "topic", topic);
       fuse_core::getParamRequired(nh, "target_frame", target_frame);

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -77,9 +77,7 @@ struct Imu2DParams : public ParameterBase
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
 
-      double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
-      throttle_period.fromSec(throttle_period_double);
+      throttle_period.fromSec(fuse_core::getPositiveParam(nh, "throttle_period", throttle_period.toSec(), false));
 
       nh.getParam("remove_gravitational_acceleration", remove_gravitational_acceleration);
       nh.getParam("gravitational_acceleration", gravitational_acceleration);

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -79,9 +79,7 @@ struct Odometry2DParams : public ParameterBase
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
 
-      double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
-      throttle_period.fromSec(throttle_period_double);
+      throttle_period.fromSec(fuse_core::getPositiveParam(nh, "throttle_period", throttle_period.toSec(), false));
 
       fuse_core::getParamRequired(nh, "topic", topic);
       fuse_core::getParamRequired(nh, "twist_target_frame", twist_target_frame);

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -73,9 +73,7 @@ struct Pose2DParams : public ParameterBase
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
 
-      double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
-      throttle_period.fromSec(throttle_period_double);
+      throttle_period.fromSec(fuse_core::getPositiveParam(nh, "throttle_period", throttle_period.toSec(), false));
 
       fuse_core::getParamRequired(nh, "topic", topic);
       fuse_core::getParamRequired(nh, "target_frame", target_frame);

--- a/fuse_models/include/fuse_models/parameters/twist_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/twist_2d_params.h
@@ -71,9 +71,7 @@ struct Twist2DParams : public ParameterBase
       nh.getParam("disable_checks", disable_checks);
       nh.getParam("queue_size", queue_size);
 
-      double throttle_period_double = throttle_period.toSec();
-      fuse_core::getPositiveParam(nh, "throttle_period", throttle_period_double, false);
-      throttle_period.fromSec(throttle_period_double);
+      throttle_period.fromSec(fuse_core::getPositiveParam(nh, "throttle_period", throttle_period.toSec(), false));
 
       fuse_core::getParamRequired(nh, "topic", topic);
       fuse_core::getParamRequired(nh, "target_frame", target_frame);


### PR DESCRIPTION
This fixes the throttle period retrieval, which wasn't retrieved properly from the ROS param server.

It also checks the keep callback isn't `nullptr`, although that wasn't an issue.