### PR TITLE
Publish timer spinner

### DIFF
--- a/fuse_models/include/fuse_models/odometry_2d_publisher.h
+++ b/fuse_models/include/fuse_models/odometry_2d_publisher.h
@@ -52,6 +52,7 @@
 #include <tf2_ros/transform_listener.h>
 
 #include <memory>
+#include <mutex>
 #include <string>
 
 namespace fuse_models
@@ -204,6 +205,16 @@ protected:
                                                                       //!< throttle messages, that can be reset on start
 
   ros::Timer publish_timer_;
+
+  ros::NodeHandle publish_timer_node_handle_;        //!< A dedicated node handle for the publish timer, so it can use
+                                                     //!< its own callback queue
+  ros::AsyncSpinner publish_timer_spinner_;          //!< A dedicated async spinner for the publish timer that manages
+                                                     //!< its callback queue with a dedicated thread
+  ros::CallbackQueue publish_timer_callback_queue_;  //!< A dedicated callback queue for the publish timer
+
+  std::mutex mutex_;  //!< A mutex to protect the access to the attributes used concurrently by the notifyCallback and
+                      //!< publishTimerCallback methods:
+                      //!< latest_stamp_, latest_covariance_stamp_, odom_output_ and acceleration_output_
 };
 
 }  // namespace fuse_models

--- a/fuse_models/test/test_graph_ignition.cpp
+++ b/fuse_models/test/test_graph_ignition.cpp
@@ -52,6 +52,7 @@
 
 #include <chrono>
 #include <future>
+#include <utility>
 #include <string>
 
 /**
@@ -70,7 +71,7 @@ void transactionCallback(fuse_core::Transaction::SharedPtr transaction)
 /**
  * @brief Static variable to hold the last unit test error description
  */
-static std::string failure_description;
+static std::string failure_description;  // NOLINT(runtime/string)
 
 /**
  * @brief Compare all the properties of two Variable objects


### PR DESCRIPTION
# Changelog

The main contribution of this PR is a **dedicated spinner** for the `publishTimerCallback` callback.
    
This reduces the jitter in the output topics and TF transform stamp because it allows the `notifyCallback` and `publishTimerCallback` callbacks to run concurrently. The `notifyCallback` callback might take longer than the timer period sometimes, mostly because the covariance computation is an expensive operation.

:warning: There is a subtle change of behaviour with this implementation:
* **Before**, the `publishTimerCallback` callback overwrote the `odom_output_` and `acceleration_output_` with the predicted state.
* **Now** it does not, and if it gets called twice or more times consecutively, it predicts since the last time the state was computed and updated in the `notifyCallback` callback. With the `notifyCallback` and `publishTimerCallback` callbacks running concurrently it is not trivial to keep the previous behaviour efficiently, because we would have to lock the entire callbacks to avoid the `publishTimerCallback` callback to overwrite a new state being computed concurrently in the `notifyCallback` callback.

That being said, the predicted state is likely the same in both implementations. That is, the result is likely the same if we use multiple steps or a single one to predict the last state forward to the current time.

This also fixes some `roslint` errors version `0.12.0`.

# Results

In order to evaluate this PR I've used the following configuration:
``` yaml
lag_duration: 5.0
optimization_frequency: 10.0

odometry_publisher:
  publish_frequency: 20.0
```

I didn't throttle any of the inputs and I also stressed all the cores in the system with `stress --cpu $(nproc)`.

The `lag_duration` of `5.0s`, which is relative large, makes the `notifyCallback` callback slower, because the covariance computation takes more time with a larger problem, and simulate high load conditions.

The `publish_frequency` is twice faster than the `optimization_frequency`. This is a very common configuration, since each optimization cycle could be expensive, as well as the covariance computation, which is trigger after each optimization cycle, i.e. the `notifyCallback` is called.

In order to evaluate the jitter on the output stamp, we simply compute the `header.stamp` difference between consecutive messages. This is what we have in the following GIFs and images.

With `cpr-devel` we get:
![CORE-17540-cpr-devel-simplescreenrecorder-2020-11-03_20 00 42](https://user-images.githubusercontent.com/382167/98078755-edd20080-1e72-11eb-9e7b-374e7b6a2a36.gif)

With this PR we get (lower quality GIF, so it can be uploaded here):
![CORE-17540-publish-timer-spinner-simplescreenrecorder-2020-11-03_19 59 04-scale-620](https://user-images.githubusercontent.com/382167/98079130-a0a25e80-1e73-11eb-98db-83b4a65fb3f9.gif)

Note the scale in the `y`-axis is going from `0.5` to `0.5`, so the difference is almost constant: `0.05`, which is the period that corresponds for the `publish_frequency` param: `20Hz`.

Similarly, with `cpr-devel` we've observed this on a robot:
![CORE-17540-base-1-bag-slam-pose-stamp-dy-Screenshot from 2020-11-04 07-36-01](https://user-images.githubusercontent.com/382167/98079311-d9dace80-1e73-11eb-9b19-89d6793ee911.png)

![CORE-17540-base-1-bag-slam-pose-stamp-dy-zoomed-in-Screenshot from 2020-11-04 07-37-00](https://user-images.githubusercontent.com/382167/98079314-da736500-1e73-11eb-9f15-db1971794c9e.png)

I tested this PR with these logging messages in order to confirm the `notifyCallback` and `publishTimerCallback` were running concurrently:
``` diff
$ git diff
diff --git a/fuse_models/src/odometry_2d_publisher.cpp b/fuse_models/src/odometry_2d_publisher.cpp
index 216ffbc..fe6d567 100644
--- a/fuse_models/src/odometry_2d_publisher.cpp
+++ b/fuse_models/src/odometry_2d_publisher.cpp
@@ -105,6 +105,7 @@ void Odometry2DPublisher::notifyCallback(
   fuse_core::Transaction::ConstSharedPtr transaction,
   fuse_core::Graph::ConstSharedPtr graph)
 {
+  ROS_ERROR_STREAM("notifyCallback BEGIN");
   TRACE_PRETTY_FUNCTION();
 
   // Find the most recent common timestamp
@@ -118,6 +119,7 @@ void Odometry2DPublisher::notifyCallback(
 
     ROS_WARN_STREAM_THROTTLE(
         10.0, "Failed to find a matching set of state variables with device id '" << device_id_ << "'.");
+    ROS_ERROR_STREAM("notifyCallback END ABORT TIME_ZERO");
     return;
   }
 
@@ -144,6 +146,7 @@ void Odometry2DPublisher::notifyCallback(
   {
     std::lock_guard<std::mutex> lock(mutex_);
     latest_stamp_ = latest_stamp;
+    ROS_ERROR_STREAM("notifyCallback END ABORT getState");
     return;
   }
 
@@ -219,6 +222,7 @@ void Odometry2DPublisher::notifyCallback(
     odom_output_ = odom_output;
     acceleration_output_ = acceleration_output;
   }
+  ROS_ERROR_STREAM("notifyCallback END");
 }
 
 void Odometry2DPublisher::onStart()
@@ -309,6 +313,7 @@ bool Odometry2DPublisher::getState(
 
 void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
 {
+  ROS_WARN_STREAM("publishTimerCallback BEGIN");
   ros::Time latest_stamp;
   ros::Time latest_covariance_stamp;
   nav_msgs::Odometry odom_output;
@@ -325,6 +330,7 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
   if (latest_stamp == Synchronizer::TIME_ZERO)
   {
     ROS_WARN_STREAM_FILTER(&delayed_throttle_filter_, "No valid state data yet. Delaying tf broadcast.");
+    ROS_WARN_STREAM("publishTimerCallback END ABORT TIME_ZERO");
     return;
   }
 
@@ -487,12 +493,14 @@ void Odometry2DPublisher::publishTimerCallback(const ros::TimerEvent& event)
         ROS_WARN_STREAM_THROTTLE(5.0, "Could not lookup the " << params_.base_link_frame_id << "->" <<
           params_.odom_frame_id << " transform. Error: " << e.what());
 
+        ROS_WARN_STREAM("publishTimerCallback END ABORT TF");
         return;
       }
     }
 
     tf_broadcaster_.sendTransform(trans);
   }
+  ROS_WARN_STREAM("publishTimerCallback END");
 }
 
 }  // namespace fuse_models
```

They indeed ran concurrently, according to this output logs:
``` bash
[ WARN] [/fuse_rl] [1604427008.980635191, 5802.400000000]: publishTimerCallback BEGIN
[ERROR] [/fuse_rl] [1604427009.007812830, 5802.420000000]: notifyCallback BEGIN
[ WARN] [/fuse_rl] [1604427009.032378061, 5802.450000000]: publishTimerCallback END
[ WARN] [/fuse_rl] [1604427009.032427925, 5802.450000000]: publishTimerCallback BEGIN
[ERROR] [/fuse_rl] [1604427009.034918625, 5802.450000000]: notifyCallback END
[ WARN] [/fuse_rl] [1604427009.042091747, 5802.460000000]: publishTimerCallback END
[ WARN] [/fuse_rl] [1604427009.078790191, 5802.500000000]: publishTimerCallback BEGIN
[ERROR] [/fuse_rl] [1604427009.102143620, 5802.520000000]: notifyCallback BEGIN
[ WARN] [/fuse_rl] [1604427009.109325819, 5802.530000000]: publishTimerCallback END
[ERROR] [/fuse_rl] [1604427009.115664623, 5802.530000000]: notifyCallback END
```

Once this is merged and tested a bit on the robots, my plan is to send this same PR upstream.