### PR TITLE
SES-2447: Include fixes and ceres 2.0.0

### DIFF
--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -127,6 +127,7 @@ install(
 if(CATKIN_ENABLE_TESTING)
   find_package(roslint REQUIRED)
   find_package(rostest REQUIRED)
+  find_package(geometry_msgs REQUIRED)
 
   # Lint tests
   set(ROSLINT_CPP_OPTS "--filter=-build/c++11,-runtime/references")
@@ -437,6 +438,12 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(test_throttled_callback
     ${PROJECT_NAME}
     ${catkin_LIBRARIES}
+  )
+  target_include_directories(test_throttled_callback
+    PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+      ${geometry_msgs_INCLUDE_DIRS}
   )
   set_target_properties(test_throttled_callback
     PROPERTIES

--- a/fuse_core/include/fuse_core/autodiff_local_parameterization.h
+++ b/fuse_core/include/fuse_core/autodiff_local_parameterization.h
@@ -217,7 +217,8 @@ bool AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLoca
   return ceres::internal::AutoDiff<MinusFunctor, double, kGlobalSize, kGlobalSize>
     ::Differentiate(*minus_functor_, parameter_ptrs, kLocalSize, delta, jacobian_ptrs);
 #else
-  return ceres::internal::AutoDifferentiate<kGlobalSize, ceres::internal::StaticParameterDims<kGlobalSize, kGlobalSize>>(
+  using StaticParameters = ceres::internal::StaticParameterDims<kGlobalSize, kGlobalSize>;
+  return ceres::internal::AutoDifferentiate<kLocalSize, StaticParameters>(
       *minus_functor_, parameter_ptrs, kLocalSize, delta, jacobian_ptrs);
 #endif
 }

--- a/fuse_core/include/fuse_core/autodiff_local_parameterization.h
+++ b/fuse_core/include/fuse_core/autodiff_local_parameterization.h
@@ -190,7 +190,7 @@ bool AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLoca
   return ceres::internal::AutoDiff<PlusFunctor, double, kGlobalSize, kLocalSize>
     ::Differentiate(*plus_functor_, parameter_ptrs, kGlobalSize, x_plus_delta, jacobian_ptrs);
 #else
-  return ceres::internal::AutoDifferentiate<ceres::internal::StaticParameterDims<kGlobalSize, kLocalSize>>(
+  return ceres::internal::AutoDifferentiate<kGlobalSize, ceres::internal::StaticParameterDims<kGlobalSize, kLocalSize>>(
       *plus_functor_, parameter_ptrs, kGlobalSize, x_plus_delta, jacobian_ptrs);
 #endif
 }
@@ -217,7 +217,7 @@ bool AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLoca
   return ceres::internal::AutoDiff<MinusFunctor, double, kGlobalSize, kGlobalSize>
     ::Differentiate(*minus_functor_, parameter_ptrs, kLocalSize, delta, jacobian_ptrs);
 #else
-  return ceres::internal::AutoDifferentiate<ceres::internal::StaticParameterDims<kGlobalSize, kGlobalSize>>(
+  return ceres::internal::AutoDifferentiate<kGlobalSize, ceres::internal::StaticParameterDims<kGlobalSize, kGlobalSize>>(
       *minus_functor_, parameter_ptrs, kLocalSize, delta, jacobian_ptrs);
 #endif
 }

--- a/fuse_core/package.xml
+++ b/fuse_core/package.xml
@@ -21,6 +21,7 @@
   <depend version_gte="1.13.8">rosconsole</depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>geometry_msgs</test_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml" />


### PR DESCRIPTION
Internal ticket is SES-2447, for that effort we see `fuse_core` and `fuse_variables` failing to compile unit tests.

- Fixing the missing include on `geometry_msgs` for fuse_core is straightforward.
- The `autodiff_local_parameterization.h` file however reaches into ceres internal headers, with the wider effort of SES-2447 we'll be on Ceres 2.0.0, which added a template argument, see the commit message on 96b8d139c912345e563d8e29a9b589907c7e4fe3. In that commit I used `kGlobalSize` for both callsites, however, that results in `Check failed: kNumResiduals == dynamic_num_outputs (3 vs. 2)` at test run time, so then I switched the second callsite to `kLocalSize`, this makes unit tests pass, but I'm unsure if that's because this is correct, or whether this is because now the numbers match the dimensions from the unit tests.  @efernandez , I'm happy to help you get your developer setup to test / run this locally. Edit: It seems these functions are only exercised for unit tests, as we only encounter these compilation errors when building the tests, not when building the main sdk.

fyi @mikepurvis 