### PR TITLE
SES-4299 Use Manifold

### DIFF
--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -35,7 +35,43 @@ catkin_package(
 ###########
 ## Build ##
 ###########
-add_compile_options(-Wall -Werror)
+
+# Disable warnings about array bounds with -Wno-array-bounds until gcc 12 fixes this bug:
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106247
+#
+# Also reported in Eigen, and confirmed to be due to gcc 12:
+# https://gitlab.com/libeigen/eigen/-/issues/2506
+#
+# In file included from include/immintrin.h:43,
+#                  from include/eigen3/Eigen/src/Core/util/ConfigureVectorization.h:361,
+#                  from include/eigen3/Eigen/Core:22,
+#                  from include/fuse_core/fuse_macros.h:63,
+#                  from include/fuse_core/loss.h:37,
+#                  from include/fuse_core/constraint.h:37,
+#                  from src/fuse/fuse_constraints/include/fuse_constraints/relative_orientation_3d_stamped_constraint.h:37,
+#                  from src/fuse/fuse_constraints/src/relative_orientation_3d_stamped_constraint.cpp:34:
+# In function ‘__m256d _mm256_loadu_pd(const double*)’,
+#     inlined from ‘Packet Eigen::internal::ploadu(const typename unpacket_traits<T>::type*) [with Packet = __vector(4) double]’ at include/eigen3/Eigen/src/Core/arch/AVX/PacketMath.h:582:129,
+#     inlined from ‘Packet Eigen::internal::ploadt(const typename unpacket_traits<T>::type*) [with Packet = __vector(4) double; int Alignment = 0]’ at include/eigen3/Eigen/src/Core/GenericPacketMath.h:969:26,
+#     inlined from ‘PacketType Eigen::internal::evaluator<Eigen::PlainObjectBase<Derived> >::packet(Eigen::Index) const [with int LoadMode = 0; PacketType = __vector(4) double; Derived = Eigen::Matrix<double, 3, 1>]’ at include/eigen3/Eigen/src/Core/CoreEvaluators.h:245:40,
+#     inlined from ‘void Eigen::internal::generic_dense_assignment_kernel<DstEvaluatorTypeT, SrcEvaluatorTypeT, Functor, Version>::assignPacket(Eigen::Index) [with int StoreMode = 32; int LoadMode = 0; PacketType = __vector(4) double; DstEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Map<Eigen::Matrix<double, -1, 1> > >; SrcEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Matrix<double, 3, 1> >; Functor = Eigen::internal::assign_op<double, double>; int Version = 0]’ at include/eigen3/Eigen/src/Core/AssignEvaluator.h:681:114,
+#     inlined from ‘static void Eigen::internal::dense_assignment_loop<Kernel, 3, 0>::run(Kernel&) [with Kernel = Eigen::internal::generic_dense_assignment_kernel<Eigen::internal::evaluator<Eigen::Map<Eigen::Matrix<double, -1, 1> > >, Eigen::internal::evaluator<Eigen::Matrix<double, 3, 1> >, Eigen::internal::assign_op<double, double>, 0>]’ at include/eigen3/Eigen/src/Core/AssignEvaluator.h:437:75,
+#     inlined from ‘void Eigen::internal::call_dense_assignment_loop(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Map<Eigen::Matrix<double, -1, 1> >; SrcXprType = Eigen::Matrix<double, 3, 1>; Functor = assign_op<double, double>]’ at include/eigen3/Eigen/src/Core/AssignEvaluator.h:785:37,
+#     inlined from ‘static void Eigen::internal::Assignment<DstXprType, SrcXprType, Functor, Eigen::internal::Dense2Dense, Weak>::run(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Map<Eigen::Matrix<double, -1, 1> >; SrcXprType = Eigen::Matrix<double, 3, 1>; Functor = Eigen::internal::assign_op<double, double>; Weak = void]’ at include/eigen3/Eigen/src/Core/AssignEvaluator.h:954:31,
+#     inlined from ‘void Eigen::internal::call_assignment_no_alias(Dst&, const Src&, const Func&) [with Dst = Eigen::Map<Eigen::Matrix<double, -1, 1> >; Src = Eigen::Matrix<double, 3, 1>; Func = assign_op<double, double>]’ at include/eigen3/Eigen/src/Core/AssignEvaluator.h:890:49,
+#     inlined from ‘void Eigen::internal::call_assignment(Dst&, const Src&, const Func&, typename enable_if<evaluator_assume_aliasing<Src>::value, void*>::type) [with Dst = Eigen::Map<Eigen::Matrix<double, -1, 1> >; Src = Eigen::Product<Eigen::Matrix<double, 3, 3, 1>, Eigen::Map<Eigen::Matrix<double, -1, 1> >, 0>; Func = assign_op<double, double>]’ at include/eigen3/Eigen/src/Core/AssignEvaluator.h:851:27,
+#     inlined from ‘void Eigen::internal::call_assignment(Dst&, const Src&) [with Dst = Eigen::Map<Eigen::Matrix<double, -1, 1> >; Src = Eigen::Product<Eigen::Matrix<double, 3, 3, 1>, Eigen::Map<Eigen::Matrix<double, -1, 1> >, 0>]’ at include/eigen3/Eigen/src/Core/AssignEvaluator.h:836:18,
+#     inlined from ‘Derived& Eigen::MatrixBase<Derived>::operator=(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Product<Eigen::Matrix<double, 3, 3, 1>, Eigen::Map<Eigen::Matrix<double, -1, 1> >, 0>; Derived = Eigen::Map<Eigen::Matrix<double, -1, 1> >]’ at include/eigen3/Eigen/src/Core/Assign.h:66:28,
+#     inlined from ‘void Eigen::EigenBase<Derived>::applyThisOnTheLeft(Dest&) const [with Dest = Eigen::Map<Eigen::Matrix<double, -1, 1> >; Derived = Eigen::Matrix<double, 3, 3, 1>]’ at include/eigen3/Eigen/src/Core/EigenBase.h:114:9:
+# include/avxintrin.h:893:24: error: array subscript ‘__m256d_u[0]’ is partly outside array bounds of ‘Eigen::internal::plain_matrix_type<Eigen::Product<Eigen::Matrix<double, 3, 3, 1>, Eigen::Map<Eigen::Matrix<double, -1, 1> >, 0>, Eigen::Dense>::type [1]’ {aka ‘Eigen::Matrix<double, 3, 1> [1]’} [-Werror=array-bounds]
+#   893 |   return *(__m256d_u *)__P;
+#       |                        ^~~
+# In file included from include/eigen3/Eigen/Core:278:
+# include/eigen3/Eigen/src/Core/AssignEvaluator.h: In member function ‘void Eigen::EigenBase<Derived>::applyThisOnTheLeft(Dest&) const [with Dest = Eigen::Map<Eigen::Matrix<double, -1, 1> >; Derived = Eigen::Matrix<double, 3, 3, 1>]’:
+# include/eigen3/Eigen/src/Core/AssignEvaluator.h:850:41: note: at offset [0, 16] into object ‘tmp’ of size 24
+#   850 |   typename plain_matrix_type<Src>::type tmp(src);
+#       |                                         ^~~
+add_compile_options(-Wall -Werror -Wno-array-bounds)
 
 # fuse_constraints library
 add_library(${PROJECT_NAME}

--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -71,7 +71,11 @@ catkin_package(
 # include/eigen3/Eigen/src/Core/AssignEvaluator.h:850:41: note: at offset [0, 16] into object ‘tmp’ of size 24
 #   850 |   typename plain_matrix_type<Src>::type tmp(src);
 #       |                                         ^~~
-add_compile_options(-Wall -Werror -Wno-array-bounds)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)
+  add_compile_options(-Wall -Werror -Wno-array-bounds)
+else()
+  add_compile_options(-Wall -Werror)
+endif()
 
 # fuse_constraints library
 add_library(${PROJECT_NAME}

--- a/fuse_constraints/CMakeLists.txt
+++ b/fuse_constraints/CMakeLists.txt
@@ -101,6 +101,9 @@ add_dependencies(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     include
+)
+target_include_directories(${PROJECT_NAME}
+  SYSTEM PUBLIC
     ${catkin_INCLUDE_DIRS}
     ${CERES_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS}

--- a/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
+++ b/fuse_constraints/include/fuse_constraints/marginal_cost_function.h
@@ -36,6 +36,7 @@
 
 #include <fuse_core/eigen.h>
 #include <fuse_core/local_parameterization.h>
+#include <fuse_core/manifold.h>
 
 #include <ceres/cost_function.h>
 
@@ -64,6 +65,7 @@ namespace fuse_constraints
 class MarginalCostFunction : public ceres::CostFunction
 {
 public:
+#if !CERES_VERSION_AT_LEAST(2, 1, 0)
   /**
    * @brief Construct a cost function instance
    *
@@ -77,6 +79,21 @@ public:
     const fuse_core::VectorXd& b,
     const std::vector<fuse_core::VectorXd>& x_bar,
     const std::vector<fuse_core::LocalParameterization::SharedPtr>& local_parameterizations);
+#else
+  /**
+   * @brief Construct a cost function instance
+   *
+   * @param[in] A                       The A matrix of the marginal cost (of the form A*(x - x_bar) + b)
+   * @param[in] b                       The b vector of the marginal cost (of the form A*(x - x_bar) + b)
+   * @param[in] x_bar                   The linearization point of the involved variables
+   * @param[in] manifolds               The manifold associated with the variable
+   */
+  MarginalCostFunction(
+    const std::vector<fuse_core::MatrixXd>& A,
+    const fuse_core::VectorXd& b,
+    const std::vector<fuse_core::VectorXd>& x_bar,
+    const std::vector<fuse_core::Manifold::SharedPtr>& manifolds);
+#endif
 
   /**
    * @brief Destructor
@@ -95,7 +112,11 @@ public:
 private:
   const std::vector<fuse_core::MatrixXd>& A_;  //!< The A matrices of the marginal cost
   const fuse_core::VectorXd& b_;  //!< The b vector of the marginal cost
+#if !CERES_VERSION_AT_LEAST(2, 1, 0)
   const std::vector<fuse_core::LocalParameterization::SharedPtr>& local_parameterizations_;  //!< Parameterizations
+#else
+  const std::vector<fuse_core::Manifold::SharedPtr>& manifolds_;  //!< Parameterizations
+#endif
   const std::vector<fuse_core::VectorXd>& x_bar_;  //!< The linearization point of each variable
 };
 

--- a/fuse_constraints/include/fuse_constraints/marginalize_variables.h
+++ b/fuse_constraints/include/fuse_constraints/marginalize_variables.h
@@ -39,7 +39,6 @@
 #include <fuse_core/constraint.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/graph.h>
-#include <fuse_core/local_parameterization.h>
 #include <fuse_core/fuse_macros.h>
 #include <fuse_core/transaction.h>
 #include <fuse_core/variable.h>

--- a/fuse_constraints/src/marginal_cost_function.cpp
+++ b/fuse_constraints/src/marginal_cost_function.cpp
@@ -33,6 +33,7 @@
  */
 #include <fuse_constraints/marginal_cost_function.h>
 
+#include <fuse_core/ceres_macros.h>
 #include <fuse_core/eigen.h>
 #include <fuse_core/local_parameterization.h>
 
@@ -97,8 +98,13 @@ bool MarginalCostFunction::Evaluate(
         if (local_parameterizations_[i])
         {
           const auto& local_parameterization = local_parameterizations_[i];
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+          fuse_core::MatrixXd J_local(local_parameterization->TangentSize(), local_parameterization->AmbientSize());
+          local_parameterization->MinusJacobian(parameters[i], J_local.data());
+#else
           fuse_core::MatrixXd J_local(local_parameterization->LocalSize(), local_parameterization->GlobalSize());
           local_parameterization->ComputeMinusJacobian(parameters[i], J_local.data());
+#endif
           Eigen::Map<fuse_core::MatrixXd>(jacobians[i], num_residuals(), parameter_block_sizes()[i]) = A_[i] * J_local;
         }
         else

--- a/fuse_constraints/src/marginal_cost_function.cpp
+++ b/fuse_constraints/src/marginal_cost_function.cpp
@@ -35,7 +35,6 @@
 
 #include <fuse_core/ceres_macros.h>
 #include <fuse_core/eigen.h>
-#include <fuse_core/local_parameterization.h>
 
 #include <Eigen/Core>
 
@@ -46,6 +45,7 @@
 namespace fuse_constraints
 {
 
+#if !CERES_VERSION_AT_LEAST(2, 1, 0)
 MarginalCostFunction::MarginalCostFunction(
     const std::vector<fuse_core::MatrixXd>& A,
     const fuse_core::VectorXd& b,
@@ -62,6 +62,24 @@ MarginalCostFunction::MarginalCostFunction(
     mutable_parameter_block_sizes()->push_back(x_bar.size());
   }
 }
+#else
+MarginalCostFunction::MarginalCostFunction(
+    const std::vector<fuse_core::MatrixXd>& A,
+    const fuse_core::VectorXd& b,
+    const std::vector<fuse_core::VectorXd>& x_bar,
+    const std::vector<fuse_core::Manifold::SharedPtr>& manifolds) :
+  A_(A),
+  b_(b),
+  manifolds_(manifolds),
+  x_bar_(x_bar)
+{
+  set_num_residuals(b_.rows());
+  for (const auto& x_bar : x_bar_)
+  {
+    mutable_parameter_block_sizes()->push_back(x_bar.size());
+  }
+}
+#endif
 
 bool MarginalCostFunction::Evaluate(
   double const* const* parameters,
@@ -74,10 +92,17 @@ bool MarginalCostFunction::Evaluate(
   for (size_t i = 0; i < A_.size(); ++i)
   {
     fuse_core::VectorXd delta(A_[i].cols());
+#if !CERES_VERSION_AT_LEAST(2, 1, 0)
     if (local_parameterizations_[i])
     {
       local_parameterizations_[i]->Minus(x_bar_[i].data(), parameters[i], delta.data());
     }
+#else 
+    if (manifolds_[i])
+    {
+      manifolds_[i]->Minus(parameters[i], x_bar_[i].data() delta.data());
+    }
+#endif
     else
     {
       for (int j = 0; j < x_bar_[i].rows(); ++j)
@@ -95,6 +120,7 @@ bool MarginalCostFunction::Evaluate(
     {
       if (jacobians[i])
       {
+#if !CERES_VERSION_AT_LEAST(2, 1, 0)
         if (local_parameterizations_[i])
         {
           const auto& local_parameterization = local_parameterizations_[i];
@@ -107,6 +133,15 @@ bool MarginalCostFunction::Evaluate(
 #endif
           Eigen::Map<fuse_core::MatrixXd>(jacobians[i], num_residuals(), parameter_block_sizes()[i]) = A_[i] * J_local;
         }
+#else
+        if (manifolds_[i])
+        {
+          const auto& manifold = manifolds_[i];
+          fuse_core::MatrixXd J_local(manifold->TangentSize(), manifold->AmbientSize());
+          local_parameterization->MinusJacobian(parameters[i], J_local.data());
+          Eigen::Map<fuse_core::MatrixXd>(jacobians[i], num_residuals(), parameter_block_sizes()[i]) = A_[i] * J_local;
+        }
+#endif
         else
         {
           Eigen::Map<fuse_core::MatrixXd>(jacobians[i], num_residuals(), parameter_block_sizes()[i]) = A_[i];

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -35,6 +35,7 @@
 #include <fuse_constraints/marginalize_variables.h>
 #include <fuse_constraints/uuid_ordering.h>
 #include <fuse_constraints/variable_constraints.h>
+#include <fuse_core/ceres_macros.h>
 #include <fuse_core/uuid.h>
 
 #include <boost/iterator/transform_iterator.hpp>
@@ -342,14 +343,23 @@ LinearTerm linearize(
     {
       if (local_parameterization)
       {
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+        jacobian.resize(Eigen::NoChange, local_parameterization->TangentSize());
+#else
         jacobian.resize(Eigen::NoChange, local_parameterization->LocalSize());
+#endif
       }
       jacobian.setZero();
     }
     else if (local_parameterization)
     {
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+      fuse_core::MatrixXd J(local_parameterization->AmbientSize(), local_parameterization->TangentSize());
+      local_parameterization->PlusJacobian(variable_values[index], J.data());
+#else
       fuse_core::MatrixXd J(local_parameterization->GlobalSize(), local_parameterization->LocalSize());
       local_parameterization->ComputeJacobian(variable_values[index], J.data());
+#endif
       jacobian *= J;
     }
     if (local_parameterization)

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -35,6 +35,8 @@
 #include <fuse_constraints/marginalize_variables.h>
 #include <fuse_constraints/uuid_ordering.h>
 #include <fuse_constraints/variable_constraints.h>
+#include <fuse_core/local_parameterization.h>
+#include <fuse_core/manifold.h>
 #include <fuse_core/ceres_macros.h>
 #include <fuse_core/uuid.h>
 
@@ -337,6 +339,7 @@ LinearTerm linearize(
   {
     const auto& variable_uuid = variable_uuids[index];
     const auto& variable = graph.getVariable(variable_uuid);
+#if !CERES_VERSION_AT_LEAST(2, 1, 0)
     auto local_parameterization = variable.localParameterization();
     auto& jacobian = result.A[index];
     if (variable.holdConstant())
@@ -366,6 +369,28 @@ LinearTerm linearize(
     {
       delete local_parameterization;
     }
+#else
+    auto manifold = variable.manifold();
+    auto& jacobian = result.A[index];
+    if (variable.holdConstant())
+    {
+      if (manifold)
+      {
+        jacobian.resize(Eigen::NoChange, manifold->TangentSize());
+      }
+      jacobian.setZero();
+    }
+    else if (manifold)
+    {
+      fuse_core::MatrixXd J(manifold->AmbientSize(), manifold->TangentSize());
+      manifold->PlusJacobian(variable_values[index], J.data());
+      jacobian *= J;
+    }
+    if (manifold)
+    {
+      delete manifoldn;
+    } 
+#endif
   }
 
   // Correct A and b for the effects of the loss function

--- a/fuse_constraints/test/test_marginal_constraint.cpp
+++ b/fuse_constraints/test/test_marginal_constraint.cpp
@@ -207,11 +207,11 @@ TEST(MarginalConstraint, LocalParameterization)
   fuse_core::Vector1d expected_residuals;
   expected_residuals << 10.581088914;  // 5.0 * 0.15  +  6.0 * -0.2  +  7.0 * 0.433012702   +   8.0
   fuse_core::MatrixXd expected_jacobian1(1, 4);
-  expected_jacobian1 << -13.29593, 3.86083, 9.164586, 12.818822;
+  expected_jacobian1 << 13.29593, -3.86083, -9.164586, -12.818822;
   // A1 * J_local
-  // [5.0, 6.0, 7.0] * [-0.720368,  1.491122,  1.052086,  -0.388248]
-  //                   [-0.388248, -1.052086,  1.491122,   0.720368]
-  //                   [-1.052086,  0.388248, -0.720368,   1.491122]
+  // [5.0, 6.0, 7.0] * [0.720368, -1.491122, -1.052086,  0.388248]
+  //                   [0.388248,  1.052086, -1.491122, -0.720368]
+  //                   [1.052086, -0.388248,  0.720368, -1.491122]
 
   EXPECT_MATRIX_NEAR(expected_residuals, actual_residuals, 1.0e-5);
   EXPECT_MATRIX_NEAR(expected_jacobian1, actual_jacobian1, 1.0e-5);

--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -59,6 +59,9 @@ add_dependencies(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     include
+)
+target_include_directories(${PROJECT_NAME}
+  SYSTEM PUBLIC
     ${Boost_INCLUDE_DIRS}
     ${catkin_INCLUDE_DIRS}
     ${CERES_INCLUDE_DIRS}
@@ -87,6 +90,9 @@ add_dependencies(fuse_echo
 target_include_directories(fuse_echo
   PUBLIC
     include
+)
+target_include_directories(fuse_echo
+  SYSTEM PUBLIC
     ${catkin_INCLUDE_DIRS}
 )
 target_link_libraries(fuse_echo

--- a/fuse_core/include/fuse_core/autodiff_local_parameterization.h
+++ b/fuse_core/include/fuse_core/autodiff_local_parameterization.h
@@ -212,7 +212,9 @@ bool AutoDiffLocalParameterization<PlusFunctor, MinusFunctor, kGlobalSize, kLoca
   double delta[kLocalSize] = {};  // zero-initialize
 
   const double* parameter_ptrs[2] = {x, x};
-  double* jacobian_ptrs[2] = {NULL, jacobian};
+  // We only need to compute the Jacobian w.r.t. the first argument, see:
+  // https://github.com/ceres-solver/ceres-solver/blob/77497373193a6304a67d0/include/ceres/autodiff_manifold.h#L244-L246
+  double* jacobian_ptrs[2] = {jacobian, NULL};
 #if !CERES_VERSION_AT_LEAST(2, 0, 0)
   return ceres::internal::AutoDiff<MinusFunctor, double, kGlobalSize, kGlobalSize>
     ::Differentiate(*minus_functor_, parameter_ptrs, kLocalSize, delta, jacobian_ptrs);

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -34,11 +34,21 @@
 #ifndef FUSE_CORE_LOCAL_PARAMETERIZATION_H
 #define FUSE_CORE_LOCAL_PARAMETERIZATION_H
 
+#include <fuse_core/ceres_macros.h>
 #include <fuse_core/fuse_macros.h>
 #include <fuse_core/serialization.h>
 
 #include <boost/serialization/access.hpp>
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+// Local parameterizations got marked as deprecated in favour of Manifold in version 2.1.0, see
+// https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc
+// and they got removed in 2.2.0, see
+// https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3
+#include <ceres/manifold.h>
+#else
 #include <ceres/local_parameterization.h>
+#endif
 
 
 namespace fuse_core
@@ -54,11 +64,17 @@ namespace fuse_core
  *
  * See the Ceres documentation for more details. http://ceres-solver.org/nnls_modeling.html#localparameterization
  */
-class LocalParameterization : public ceres::LocalParameterization
+class LocalParameterization : public
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+                              ceres::Manifold
+#else
+                              ceres::LocalParameterization
+#endif
 {
 public:
   FUSE_SMART_PTR_ALIASES_ONLY(LocalParameterization);
 
+#if !CERES_VERSION_AT_LEAST(2, 1, 0)
   /**
    * @brief Generalization of the subtraction operation
    *
@@ -88,6 +104,7 @@ public:
   virtual bool ComputeMinusJacobian(
     const double* x,
     double* jacobian) const = 0;
+#endif
 
 private:
   // Allow Boost Serialization access to private methods

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -40,16 +40,11 @@
 
 #include <boost/serialization/access.hpp>
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-// Local parameterizations got marked as deprecated in favour of Manifold in version 2.1.0, see
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
+// Local parameterizations is removed in favour of Manifold in
+// version 2.2.0, see
 // https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc
-// and they got removed in 2.2.0, see
-// https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3
-#include <ceres/manifold.h>
-#else
 #include <ceres/local_parameterization.h>
-#endif
-
 
 namespace fuse_core
 {
@@ -64,17 +59,11 @@ namespace fuse_core
  *
  * See the Ceres documentation for more details. http://ceres-solver.org/nnls_modeling.html#localparameterization
  */
-class LocalParameterization : public
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-                              ceres::Manifold
-#else
-                              ceres::LocalParameterization
-#endif
+class LocalParameterization : public ceres::LocalParameterization
 {
 public:
   FUSE_SMART_PTR_ALIASES_ONLY(LocalParameterization);
 
-#if !CERES_VERSION_AT_LEAST(2, 1, 0)
   /**
    * @brief Generalization of the subtraction operation
    *
@@ -104,7 +93,6 @@ public:
   virtual bool ComputeMinusJacobian(
     const double* x,
     double* jacobian) const = 0;
-#endif
 
 private:
   // Allow Boost Serialization access to private methods
@@ -123,5 +111,7 @@ private:
 };
 
 }  // namespace fuse_core
+
+#endif 
 
 #endif  // FUSE_CORE_LOCAL_PARAMETERIZATION_H

--- a/fuse_core/include/fuse_core/manifold.h
+++ b/fuse_core/include/fuse_core/manifold.h
@@ -1,0 +1,147 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2024, Clearpath Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CORE_MANIFOLD_H
+#define FUSE_CORE_MANIFOLD_H
+
+#include <fuse_core/ceres_macros.h>
+#include <fuse_core/fuse_macros.h>
+#include <fuse_core/serialization.h>
+
+#include <boost/serialization/access.hpp>
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+// Local parameterizations got marked as deprecated in favour of Manifold in
+// version 2.1.0, see
+// https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc
+// and they got removed in 2.2.0, see
+// https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3
+#include <ceres/manifold.h>
+
+namespace fuse_core {
+
+/**
+ * @brief The Manifold interface definition.
+ *
+ * This class extends the Ceres Manifold class but adds methods to match the
+ * fuse::LocalParameterization API
+ *
+ * See the Ceres documentation for more details.
+ * http://ceres-solver.org/nnls_modeling.html#manifold
+ */
+class Manifold : public ceres::Manifold {
+public:
+  FUSE_SMART_PTR_ALIASES_ONLY(Manifold);
+
+  // Dimension of the ambient space in which the manifold is embedded.
+  virtual int AmbientSize() const = 0;
+
+  // Dimension of the manifold/tangent space.
+  virtual int TangentSize() const = 0;
+
+  /**
+   * @brief  x_plus_delta = Plus(x, delta),
+   *
+   * A generalization of vector addition in Euclidean space, Plus computes the
+   * result of moving along delta in the tangent space at x, and then projecting
+   * back onto the manifold that x belongs to.
+   *
+   * @param[in] x is a \p AmbientSize() vector.
+   * @param[in] delta delta is a \p TangentSize() vector.
+   * @param[out] x_plus_delta  is a \p AmbientSize() vector.
+   * @return Return value indicates if the operation was successful or not.
+   */
+  virtual bool Plus(const double *x, const double *delta,
+                    double *x_plus_delta) const = 0;
+
+  /**
+   * @brief Compute the derivative of Plus(x, delta) w.r.t delta at delta = 0,
+   * i.e.
+   *
+   * (D_2 Plus)(x, 0)
+   *
+   * @param[in] x is a \p AmbientSize() vector
+   * @param[out] jacobian is a row-major \p AmbientSize() x \p TangentSize()
+   * matrix.
+   * @return
+   */
+  virtual bool PlusJacobian(const double *x, double *jacobian) const = 0;
+
+  /**
+   * @brief y_minus_x = Minus(y, x)
+   * 
+   * Given two points on the manifold, Minus computes the change to x in the
+   * tangent space at x, that will take it to y.
+   * 
+   * @param[in] y is a \p AmbientSize() vector.
+   * @param[in] x is a \p AmbientSize() vector.
+   * @param[out] y_minus_x is a \p TangentSize() vector.
+   * @return Return value indicates if the operation was successful or not.
+   */
+  virtual bool Minus(const double *y, const double *x,
+                     double *y_minus_x) const = 0;
+
+
+  /**
+   * @brief Compute the derivative of Minus(y, x) w.r.t y at y = x, i.e
+   * 
+   *      (D_1 Minus) (x, x)
+   * 
+   * @param[in] x is a \p AmbientSize() vector.
+   * @param[out] jacobian is a row-major \p TangentSize() x \p AmbientSize() matrix.
+   * @return Return value indicates whether the operation was successful or not.
+   */
+  virtual bool MinusJacobian(const double *x, double *jacobian) const = 0;
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members
+   * in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class
+   * members
+   * @param[in] version - The version of the archive being read/written.
+   * Generally unused.
+   */
+  template <class Archive>
+  void serialize(Archive & /* archive */, const unsigned int /* version */) {}
+};
+
+} // namespace fuse_core
+
+#endif
+
+#endif // FUSE_CORE_MANIFOLD_H

--- a/fuse_core/include/fuse_core/manifold.h
+++ b/fuse_core/include/fuse_core/manifold.h
@@ -53,8 +53,7 @@ namespace fuse_core {
 /**
  * @brief The Manifold interface definition.
  *
- * This class extends the Ceres Manifold class but adds methods to match the
- * fuse::LocalParameterization API
+ * This class extends the Ceres Manifold class
  *
  * See the Ceres documentation for more details.
  * http://ceres-solver.org/nnls_modeling.html#manifold

--- a/fuse_core/include/fuse_core/manifold_adapter.h
+++ b/fuse_core/include/fuse_core/manifold_adapter.h
@@ -1,7 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2019, Locus Robotics
+ *  Copyright (c) 2024, Clearpath Robotics
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -31,63 +31,57 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#include <fuse_variables/orientation_2d_stamped.h>
+
+#ifndef FUSE_CORE_MANIFOLD_ADAPTER_H
+#define FUSE_CORE_MANIFOLD_ADAPTER_H
 
 #include <fuse_core/local_parameterization.h>
-#include <fuse_core/uuid.h>
-#include <fuse_variables/fixed_size_variable.h>
-#include <fuse_variables/stamped.h>
-#include <pluginlib/class_list_macros.hpp>
-#include <ros/time.h>
+#include <fuse_core/manifold.h>
 
-#include <boost/serialization/export.hpp>
-
-#include <ostream>
-
-
-namespace fuse_variables
-{
-
-Orientation2DStamped::Orientation2DStamped(const ros::Time& stamp, const fuse_core::UUID& device_id) :
-  FixedSizeVariable(fuse_core::uuid::generate(detail::type(), stamp, device_id)),
-  Stamped(stamp, device_id)
-{
-}
-
-void Orientation2DStamped::print(std::ostream& stream) const
-{
-  stream << type() << ":\n"
-         << "  uuid: " << uuid() << "\n"
-         << "  stamp: " << stamp() << "\n"
-         << "  device_id: " << deviceId() << "\n"
-         << "  size: " << size() << "\n"
-         << "  data:\n"
-         << "  - yaw: " << yaw() << "\n";
-}
-
-#if !CERES_VERSION_AT_LEAST(2, 2, 0)
-fuse_core::LocalParameterization* Orientation2DStamped::localParameterization() const
-{
-  return new Orientation2DLocalParameterization();
-}
-#endif
-
+// This is only needed for exactly ceres == 2.1.x
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
-fuse_core::Manifold* Orientation2DStamped::manifold() const
-{
-  return new Orientation2DManifold();
-}
-#endif
-
-}  // namespace fuse_variables
-
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation2DManifold);
-#endif
-
 #if !CERES_VERSION_AT_LEAST(2, 2, 0)
-BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation2DLocalParameterization);
+
+namespace fuse_core {
+
+class ManifoldAdapter : public fuse_core::Manifold {
+public:
+  ManifoldAdapter(LocalParameterization *local_parameterization)
+      : local_parameterization_(local_parameterization) {}
+
+  int AmbientSize() const override {
+    return local_parameterization_->GlobalSize();
+  }
+
+  int TangentSize() const override {
+    return local_parameterization_->LocalSize();
+  }
+
+  bool Plus(const double *x, const double *delta,
+            double *x_plus_delta) const override {
+    return local_parameterization_->Plus(x, delta, x_plus_delta);
+  }
+
+  bool PlusJacobian(const double *x, double *jacobian) const override {
+    return local_parameterization_->ComputeJacobian(x, jacobian);
+  }
+  
+  bool Minus(const double *y, const double *x,
+             double *y_minus_x) const override {
+    return local_parameterization_->Minus(x, y, y_minus_x);
+  }
+
+  bool MinusJacobian(const double *x, double *jacobian) const override {
+    return local_parameterization_->ComputeMinusJacobian(x, jacobian);
+  }
+
+private:
+  fuse_core::LocalParameterization *local_parameterization_;
+};
+
+} // namespace fuse_core
+
+#endif
 #endif
 
-BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation2DStamped);
-PLUGINLIB_EXPORT_CLASS(fuse_variables::Orientation2DStamped, fuse_core::Variable);
+#endif // FUSE_CORE_MANIFOLD_ADAPTER_H

--- a/fuse_core/include/fuse_core/manifold_adapter.h
+++ b/fuse_core/include/fuse_core/manifold_adapter.h
@@ -44,6 +44,14 @@
 
 namespace fuse_core {
 
+/**
+ * @brief The ManifoldAdapter class takes in the old fuse LocalParameterization and implements the new Manifold API
+ *
+ * This class extends the Fuse Manifold class but adds methods to match the
+ *
+ * See the Ceres documentation for more details.
+ * http://ceres-solver.org/nnls_modeling.html#manifold
+ */
 class ManifoldAdapter : public fuse_core::Manifold {
 public:
   ManifoldAdapter(LocalParameterization *local_parameterization)

--- a/fuse_core/include/fuse_core/variable.h
+++ b/fuse_core/include/fuse_core/variable.h
@@ -34,8 +34,10 @@
 #ifndef FUSE_CORE_VARIABLE_H
 #define FUSE_CORE_VARIABLE_H
 
-#include <fuse_core/local_parameterization.h>
 #include <fuse_core/fuse_macros.h>
+#include <fuse_core/local_parameterization.h>
+#include <fuse_core/manifold.h>
+#include <fuse_core/manifold_adapter.h>
 #include <fuse_core/serialization.h>
 #include <fuse_core/uuid.h>
 
@@ -45,7 +47,6 @@
 #include <limits>
 #include <ostream>
 #include <string>
-
 
 /**
  * @brief Implementation of the clone() member function for derived classes
@@ -60,14 +61,14 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_CLONE_DEFINITION(...) \
-  fuse_core::Variable::UniquePtr clone() const override \
-  { \
-    return __VA_ARGS__::make_unique(*this); \
+#define FUSE_VARIABLE_CLONE_DEFINITION(...)                                    \
+  fuse_core::Variable::UniquePtr clone() const override {                      \
+    return __VA_ARGS__::make_unique(*this);                                    \
   }
 
 /**
- * @brief Implementation of the serialize() and deserialize() member functions for derived classes
+ * @brief Implementation of the serialize() and deserialize() member functions
+ * for derived classes
  *
  * Usage:
  * @code{.cpp}
@@ -79,28 +80,26 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_SERIALIZE_DEFINITION(...) \
-  void serialize(fuse_core::BinaryOutputArchive& archive) const override \
-  { \
-    archive << *this; \
-  }  /* NOLINT */ \
-  void serialize(fuse_core::TextOutputArchive& archive) const override \
-  { \
-    archive << *this; \
-  }  /* NOLINT */ \
-  void deserialize(fuse_core::BinaryInputArchive& archive) override \
-  { \
-    archive >> *this; \
-  }  /* NOLINT */ \
-  void deserialize(fuse_core::TextInputArchive& archive) override \
-  { \
-    archive >> *this; \
+#define FUSE_VARIABLE_SERIALIZE_DEFINITION(...)                                \
+  void serialize(fuse_core::BinaryOutputArchive &archive) const override {     \
+    archive << *this;                                                          \
+  } /* NOLINT */                                                               \
+  void serialize(fuse_core::TextOutputArchive &archive) const override {       \
+    archive << *this;                                                          \
+  } /* NOLINT */                                                               \
+  void deserialize(fuse_core::BinaryInputArchive &archive) override {          \
+    archive >> *this;                                                          \
+  } /* NOLINT */                                                               \
+  void deserialize(fuse_core::TextInputArchive &archive) override {            \
+    archive >> *this;                                                          \
   }
 
 /**
- * @brief Implements the type() member function using the suggested implementation
+ * @brief Implements the type() member function using the suggested
+ * implementation
  *
- * Also creates a static detail::type() function that may be used without an object instance
+ * Also creates a static detail::type() function that may be used without an
+ * object instance
  *
  * Usage:
  * @code{.cpp}
@@ -112,21 +111,18 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_TYPE_DEFINITION(...) \
-  struct detail \
-  { \
-    static std::string type() \
-    { \
-      return boost::typeindex::stl_type_index::type_id<__VA_ARGS__>().pretty_name(); \
-    }  /* NOLINT */ \
-  };  /* NOLINT */ \
-  std::string type() const override \
-  { \
-    return detail::type(); \
-  }
+#define FUSE_VARIABLE_TYPE_DEFINITION(...)                                     \
+  struct detail {                                                              \
+    static std::string type() {                                                \
+      return boost::typeindex::stl_type_index::type_id<__VA_ARGS__>()          \
+          .pretty_name();                                                      \
+    } /* NOLINT */                                                             \
+  };  /* NOLINT */                                                             \
+  std::string type() const override { return detail::type(); }
 
 /**
- * @brief Convenience function that creates the required pointer aliases, clone() method, and type() method
+ * @brief Convenience function that creates the required pointer aliases,
+ * clone() method, and type() method
  *
  * Usage:
  * @code{.cpp}
@@ -138,15 +134,16 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_DEFINITIONS(...) \
-  FUSE_SMART_PTR_DEFINITIONS(__VA_ARGS__) \
-  FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__) \
-  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__) \
+#define FUSE_VARIABLE_DEFINITIONS(...)                                         \
+  FUSE_SMART_PTR_DEFINITIONS(__VA_ARGS__)                                      \
+  FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__)                                   \
+  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__)                                  \
   FUSE_VARIABLE_SERIALIZE_DEFINITION(__VA_ARGS__)
 
 /**
- * @brief Convenience function that creates the required pointer aliases, clone() method, and type() method
- *        for derived Variable classes that have fixed-sized Eigen member objects.
+ * @brief Convenience function that creates the required pointer aliases,
+ * clone() method, and type() method for derived Variable classes that have
+ * fixed-sized Eigen member objects.
  *
  * Usage:
  * @code{.cpp}
@@ -158,35 +155,38 @@
  * }
  * @endcode
  */
-#define FUSE_VARIABLE_DEFINITIONS_WITH_EIGEN(...) \
-  FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(__VA_ARGS__) \
-  FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__) \
-  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__) \
+#define FUSE_VARIABLE_DEFINITIONS_WITH_EIGEN(...)                              \
+  FUSE_SMART_PTR_DEFINITIONS_WITH_EIGEN(__VA_ARGS__)                           \
+  FUSE_VARIABLE_TYPE_DEFINITION(__VA_ARGS__)                                   \
+  FUSE_VARIABLE_CLONE_DEFINITION(__VA_ARGS__)                                  \
   FUSE_VARIABLE_SERIALIZE_DEFINITION(__VA_ARGS__)
 
-
-namespace fuse_core
-{
+namespace fuse_core {
 
 /**
  * @brief The Variable interface definition.
  *
- * A Variable defines some semantically meaningful group of one or more individual scale values. Each variable is
- * treated as a block by the optimization engine, as the values of all of its dimensions are likely to be involved
- * in the same constraints. Some common examples of variable groupings are a 2D point (x, y), 3D point (x, y, z), or
- * camera calibration parameters (fx, fy, cx, cy).
+ * A Variable defines some semantically meaningful group of one or more
+ * individual scale values. Each variable is treated as a block by the
+ * optimization engine, as the values of all of its dimensions are likely to be
+ * involved in the same constraints. Some common examples of variable groupings
+ * are a 2D point (x, y), 3D point (x, y, z), or camera calibration parameters
+ * (fx, fy, cx, cy).
  *
- * To support the Ceres optimization engine, the Variable must hold the scalar values of each dimension in a
- * _contiguous_ memory space, and must provide access to that memory location via the Variable::data() methods.
+ * To support the Ceres optimization engine, the Variable must hold the scalar
+ * values of each dimension in a _contiguous_ memory space, and must provide
+ * access to that memory location via the Variable::data() methods.
  *
- * Some Variables may require special update rules, either because they are over-parameterized, as is the case with
- * 3D rotations represented as quaternions, or because the update of the individual dimensions exhibit some nonlinear
- * properties, as is the case with rotations in general (e.g. 2D rotations have a discontinuity around &pi;). To
- * support these situations, Ceres uses an optional "local parameterization". See the Ceres documentation for more
- * details. http://ceres-solver.org/nnls_modeling.html#localparameterization
+ * Some Variables may require special update rules, either because they are
+ * over-parameterized, as is the case with 3D rotations represented as
+ * quaternions, or because the update of the individual dimensions exhibit some
+ * nonlinear properties, as is the case with rotations in general (e.g. 2D
+ * rotations have a discontinuity around &pi;). To support these situations,
+ * Ceres uses an optional "local parameterization". See the Ceres documentation
+ * for more details.
+ * http://ceres-solver.org/nnls_modeling.html#localparameterization
  */
-class Variable
-{
+class Variable {
 public:
   FUSE_SMART_PTR_ALIASES_ONLY(Variable);
 
@@ -198,20 +198,25 @@ public:
   /**
    * @brief Constructor
    *
-   * The implemented UUID generation should be deterministic such that a variable with the same metadata will always
-   * return the same UUID. Identical UUIDs produced by sensors will be treated as the same variable by the optimizer,
-   * and different UUIDs will be treated as different variables. So, two derived variables representing robot poses with
-   * the same timestamp but different UUIDs will incorrectly be treated as different variables, and two robot poses with
-   * different timestamps but the same UUID will be incorrectly treated as the same variable.
+   * The implemented UUID generation should be deterministic such that a
+   * variable with the same metadata will always return the same UUID. Identical
+   * UUIDs produced by sensors will be treated as the same variable by the
+   * optimizer, and different UUIDs will be treated as different variables. So,
+   * two derived variables representing robot poses with the same timestamp but
+   * different UUIDs will incorrectly be treated as different variables, and two
+   * robot poses with different timestamps but the same UUID will be incorrectly
+   * treated as the same variable.
    *
-   * One method of producing UUIDs that adhere to this requirement is to use the boost::uuid::name_generator() function.
-   * The type() string can be used to generate a UUID namespace for all variables of a given derived type, and the
-   * variable metadata of consequence can be converted into a carefully-formatted string or byte array and provided to
-   * the generator to create the UUID for a specific variable instance.
+   * One method of producing UUIDs that adhere to this requirement is to use the
+   * boost::uuid::name_generator() function. The type() string can be used to
+   * generate a UUID namespace for all variables of a given derived type, and
+   * the variable metadata of consequence can be converted into a
+   * carefully-formatted string or byte array and provided to the generator to
+   * create the UUID for a specific variable instance.
    *
    * @param[in] uuid The unique ID number for this variable
    */
-  explicit Variable(const UUID& uuid);
+  explicit Variable(const UUID &uuid);
 
   /**
    * @brief Destructor
@@ -221,68 +226,77 @@ public:
   /**
    * @brief Returns a UUID for this variable.
    */
-  const UUID& uuid() const { return uuid_; }
+  const UUID &uuid() const { return uuid_; }
 
   /**
    * @brief Returns a unique name for this variable type.
    *
-   * The variable type string must be unique for each class. As such, the fully-qualified class name is an excellent
-   * choice for the type string.
+   * The variable type string must be unique for each class. As such, the
+   * fully-qualified class name is an excellent choice for the type string.
    *
    * The suggested implementation for all derived classes is:
    * @code{.cpp}
-   * return return boost::typeindex::stl_type_index::type_id<Derived>().pretty_name();
+   * return return
+   * boost::typeindex::stl_type_index::type_id<Derived>().pretty_name();
    * @endcode
    *
-   * To make this easy to implement in all derived classes, the FUSE_VARIABLE_TYPE_DEFINITION() and
-   * FUSE_VARIABLE_DEFINITIONS() macro functions have been provided.
+   * To make this easy to implement in all derived classes, the
+   * FUSE_VARIABLE_TYPE_DEFINITION() and FUSE_VARIABLE_DEFINITIONS() macro
+   * functions have been provided.
    */
   virtual std::string type() const = 0;
 
   /**
    * @brief Returns the number of elements of this variable.
    *
-   * In most cases, this will be the number of degrees of freedom this variable represents. For example, a 2D pose has
-   * an x, y, and theta value, so the size will be 3. A notable exception is a 3D rotation represented as a quaternion.
-   * It only has 3 degrees of freedom, but it is represented as four elements, (w, x, y, z), so it's size will be 4.
+   * In most cases, this will be the number of degrees of freedom this variable
+   * represents. For example, a 2D pose has an x, y, and theta value, so the
+   * size will be 3. A notable exception is a 3D rotation represented as a
+   * quaternion. It only has 3 degrees of freedom, but it is represented as four
+   * elements, (w, x, y, z), so it's size will be 4.
    */
   virtual size_t size() const = 0;
 
   /**
    * @brief Returns the number of elements of the local parameterization space.
    *
-   * If you override the \p localParameterization() method, it is good practice to also override the \p localSize()
-   * method. By default, the \p size() method is used for \p localSize() as well.
+   * If you override the \p localParameterization() method, it is good practice
+   * to also override the \p localSize() method. By default, the \p size()
+   * method is used for \p localSize() as well.
    */
   virtual size_t localSize() const { return size(); }
 
   /**
    * @brief Read-only access to the variable data
    *
-   * The data elements must be contiguous (such as a C-style array double[3] or std::vector<double>), and it must
-   * contain at least Variable::size() elements. Only Variable::size() elements will be accessed externally. This
+   * The data elements must be contiguous (such as a C-style array double[3] or
+   * std::vector<double>), and it must contain at least Variable::size()
+   * elements. Only Variable::size() elements will be accessed externally. This
    * interface is provided for integration with Ceres, which uses raw pointers.
    */
-  virtual const double* data() const = 0;
+  virtual const double *data() const = 0;
 
   /**
    * @brief Read-write access to the variable data
    *
-   * The data elements must be contiguous (such as a C-style array double[3] or std::vector<double>), and it must
-   * contain at least Variable::size() elements. Only Variable::size() elements will be accessed externally. This
+   * The data elements must be contiguous (such as a C-style array double[3] or
+   * std::vector<double>), and it must contain at least Variable::size()
+   * elements. Only Variable::size() elements will be accessed externally. This
    * interface is provided for integration with Ceres, which uses raw pointers.
    */
-  virtual double* data() = 0;
+  virtual double *data() = 0;
 
   /**
-   * @brief Print a human-readable description of the variable to the provided stream.
+   * @brief Print a human-readable description of the variable to the provided
+   * stream.
    *
    * @param[out] stream The stream to write to. Defaults to stdout.
    */
-  virtual void print(std::ostream& stream = std::cout) const = 0;
+  virtual void print(std::ostream &stream = std::cout) const = 0;
 
   /**
-   * @brief Perform a deep copy of the Variable and return a unique pointer to the copy
+   * @brief Perform a deep copy of the Variable and return a unique pointer to
+   * the copy
    *
    * Unique pointers can be implicitly upgraded to shared pointers if needed.
    *
@@ -291,31 +305,69 @@ public:
    * return Derived::make_unique(*this);
    * @endcode
    *
-   * To make this easy to implement in all derived classes, the FUSE_VARIABLE_CLONE_DEFINITION() and
-   * FUSE_VARIABLE_DEFINITIONS() macros functions have been provided.
+   * To make this easy to implement in all derived classes, the
+   * FUSE_VARIABLE_CLONE_DEFINITION() and FUSE_VARIABLE_DEFINITIONS() macros
+   * functions have been provided.
    *
    * @return A unique pointer to a new instance of the most-derived Variable
    */
   virtual Variable::UniquePtr clone() const = 0;
 
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
   /**
-   * @brief Create a new Ceres local parameterization object to apply to updates of this variable
+   * @brief Create a new Ceres local parameterization object to apply to updates
+   * of this variable
    *
-   * If a local parameterization is not needed, a null pointer should be returned. If a local parameterization is
-   * needed, remember to also override the \p localSize() method to return the appropriate local parameterization
+   * If a local parameterization is not needed, a null pointer should be
+   * returned. If a local parameterization is needed, remember to also override
+   * the \p localSize() method to return the appropriate local parameterization
    * size.
    *
-   * The Ceres interface requires a raw pointer. Ceres will take ownership of the pointer and promises to properly
-   * delete the local parameterization when it is done. Additionally, fuse promises that the Variable object will
-   * outlive any generated local parameterization (i.e. the Ceres objects will be destroyed before the Variable
-   * objects). This guarantee may allow optimizations for the creation of the local parameterization objects.
+   * The Ceres interface requires a raw pointer. Ceres will take ownership of
+   * the pointer and promises to properly delete the local parameterization when
+   * it is done. Additionally, fuse promises that the Variable object will
+   * outlive any generated local parameterization (i.e. the Ceres objects will
+   * be destroyed before the Variable objects). This guarantee may allow
+   * optimizations for the creation of the local parameterization objects.
    *
    * @return A base pointer to an instance of a derived LocalParameterization
    */
-  virtual fuse_core::LocalParameterization* localParameterization() const
-  {
+  virtual fuse_core::LocalParameterization *localParameterization() const {
     return nullptr;
   }
+#endif
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  /**
+   * @brief Create a new Ceres manifold object to apply to updates of this
+   * variable
+   *
+   * If a manifold is not needed, a null pointer should be returned. If a local
+   * parameterization is needed, remember to also override the \p localSize()
+   * method to return the appropriate local parameterization size.
+   *
+   * The Ceres interface requires a raw pointer. Ceres will take ownership of
+   * the pointer and promises to properly delete the local parameterization when
+   * it is done. Additionally, fuse promises that the Variable object will
+   * outlive any generated local parameterization (i.e. the Ceres objects will
+   * be destroyed before the Variable objects). This guarantee may allow
+   * optimizations for the creation of the local parameterization objects.
+   *
+   * @return A base pointer to an instance of a derived Manifold
+   */
+  virtual fuse_core::Manifold *manifold() const {
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
+    if (!localParameterization()) {
+      return nullptr;
+    }
+    std::shared_ptr<fuse_core::Manifold> adapted_manifold =
+        std::make_shared<fuse_core::ManifoldAdapter>(localParameterization());
+    return adapted_manifold.get();
+#endif
+
+    return nullptr;
+  }
+#endif
 
   /**
    * @brief Specifies the lower bound value of each variable dimension
@@ -325,8 +377,7 @@ public:
    * @param[in] index The variable dimension of interest
    * @return The lower bound for the requested variable dimension
    */
-  virtual double lowerBound(size_t index) const
-  {
+  virtual double lowerBound(size_t index) const {
     return std::numeric_limits<double>::lowest();
   }
 
@@ -338,18 +389,15 @@ public:
    * @param[in] index The variable dimension of interest
    * @return The upper bound for the requested variable dimension
    */
-  virtual double upperBound(size_t index) const
-  {
+  virtual double upperBound(size_t index) const {
     return std::numeric_limits<double>::max();
   }
 
   /**
-   * @brief Specifies if the value of the variable should not be changed during optimization
+   * @brief Specifies if the value of the variable should not be changed during
+   * optimization
    */
-  virtual bool holdConstant() const
-  {
-    return false;
-  }
+  virtual bool holdConstant() const { return false; }
 
   /**
    * @brief Serialize this Variable into the provided binary archive
@@ -361,7 +409,8 @@ public:
    *
    * @param[out] archive - The archive to serialize this variable into
    */
-  virtual void serialize(fuse_core::BinaryOutputArchive& /* archive */) const = 0;
+  virtual void
+  serialize(fuse_core::BinaryOutputArchive & /* archive */) const = 0;
 
   /**
    * @brief Serialize this Variable into the provided text archive
@@ -373,7 +422,8 @@ public:
    *
    * @param[out] archive - The archive to serialize this variable into
    */
-  virtual void serialize(fuse_core::TextOutputArchive& /* archive */) const = 0;
+  virtual void
+  serialize(fuse_core::TextOutputArchive & /* archive */) const = 0;
 
   /**
    * @brief Deserialize data from the provided binary archive into this Variable
@@ -385,7 +435,7 @@ public:
    *
    * @param[in] archive - The archive holding serialized Variable data
    */
-  virtual void deserialize(fuse_core::BinaryInputArchive& /* archive */) = 0;
+  virtual void deserialize(fuse_core::BinaryInputArchive & /* archive */) = 0;
 
   /**
    * @brief Deserialize data from the provided text archive into this Variable
@@ -397,36 +447,39 @@ public:
    *
    * @param[in] archive - The archive holding serialized Variable data
    */
-  virtual void deserialize(fuse_core::TextInputArchive& /* archive */) = 0;
+  virtual void deserialize(fuse_core::TextInputArchive & /* archive */) = 0;
 
 private:
-  fuse_core::UUID uuid_;  //!< The unique ID number for this variable
+  fuse_core::UUID uuid_; //!< The unique ID number for this variable
 
   // Allow Boost Serialization access to private methods
   friend class boost::serialization::access;
 
   /**
-   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   * @brief The Boost Serialize method that serializes all of the data members
+   * in to/out of the archive
    *
-   * This method, or a combination of save() and load() methods, must be implemented by all derived classes. See
-   * documentation on Boost Serialization for information on how to implement the serialize() method.
+   * This method, or a combination of save() and load() methods, must be
+   * implemented by all derived classes. See documentation on Boost
+   * Serialization for information on how to implement the serialize() method.
    * https://www.boost.org/doc/libs/1_70_0/libs/serialization/doc/
    *
-   * @param[in/out] archive - The archive object that holds the serialized class members
-   * @param[in] version - The version of the archive being read/written. Generally unused.
+   * @param[in/out] archive - The archive object that holds the serialized class
+   * members
+   * @param[in] version - The version of the archive being read/written.
+   * Generally unused.
    */
-  template<class Archive>
-  void serialize(Archive& archive, const unsigned int /* version */)
-  {
-    archive & uuid_;
+  template <class Archive>
+  void serialize(Archive &archive, const unsigned int /* version */) {
+    archive &uuid_;
   }
 };
 
 /**
  * Stream operator implementation used for all derived Variable classes.
  */
-std::ostream& operator <<(std::ostream& stream, const Variable& variable);
+std::ostream &operator<<(std::ostream &stream, const Variable &variable);
 
-}  // namespace fuse_core
+} // namespace fuse_core
 
-#endif  // FUSE_CORE_VARIABLE_H
+#endif // FUSE_CORE_VARIABLE_H

--- a/fuse_core/test/test_local_parameterization.cpp
+++ b/fuse_core/test/test_local_parameterization.cpp
@@ -151,8 +151,8 @@ TEST(LocalParameterization, MinusJacobian)
 #endif
 
   fuse_core::MatrixXd expected(2, 3);
-  expected << 0.5, 0.0, 0.0,
-              0.0, 0.2, 0.0;
+  expected << -0.5, 0.0, 0.0,
+              0.0, -0.2, 0.0;
 
   EXPECT_TRUE(success);
   EXPECT_MATRIX_NEAR(expected, actual, 1.0e-5);

--- a/fuse_graphs/CMakeLists.txt
+++ b/fuse_graphs/CMakeLists.txt
@@ -62,6 +62,9 @@ add_dependencies(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     include
+)
+target_include_directories(${PROJECT_NAME}
+  SYSTEM PUBLIC
     ${Boost_INCLUDE_DIRS}
     ${catkin_INCLUDE_DIRS}
     ${CERES_INCLUDE_DIRS}
@@ -120,6 +123,9 @@ if(CATKIN_ENABLE_TESTING)
   target_include_directories(test_hash_graph
     PRIVATE
       include
+  )
+  target_include_directories(test_hash_graph
+    SYSTEM PRIVATE
       ${Boost_INCLUDE_DIRS}
       ${catkin_INCLUDE_DIRS}
       ${CERES_INCLUDE_DIRS}

--- a/fuse_graphs/CMakeLists.txt
+++ b/fuse_graphs/CMakeLists.txt
@@ -29,7 +29,28 @@ catkin_package(
 ###########
 ## Build ##
 ###########
-add_compile_options(-Wall -Werror)
+
+# Disable warnings about maybe uninitialized variables with -Wno-maybe-uninitialized until we fix the following error:
+#
+# In file included from include/c++/12.2.0/functional:59,
+#                  from include/eigen3/Eigen/Core:85,
+#                  from include/fuse_core/fuse_macros.h:63,
+#                  from include/fuse_core/loss.h:37,
+#                  from include/fuse_core/constraint.h:37,
+#                  from src/fuse/fuse_graphs/include/fuse_graphs/hash_graph.h:38,
+#                  from src/fuse/fuse_graphs/src/hash_graph.cpp:34:
+# In copy constructor ‘std::function<_Res(_ArgTypes ...)>::function(const std::function<_Res(_ArgTypes ...)>&) [with _Res = const fuse_core::Variable&; _ArgTypes = {const std::pair<const boost::uuids::uuid, std::shared_ptr<fuse_core::Variable> >&}]’,
+#     inlined from ‘boost::iterators::transform_iterator<UnaryFunction, Iterator, Reference, Value>::transform_iterator(const Iterator&, UnaryFunc) [with UnaryFunc = std::function<const fuse_core::Variable&(const std::pair<const boost::uuids::uuid, std::shared_ptr<fuse_core::Variable> >&)>; Iterator = std::__detail::_Node_const_iterator<std::pair<const boost::uuids::uuid, std::shared_ptr<fuse_core::Variable> >, false, true>; Reference = boost::use_default; Value = boost::use_default]’ at include/boost/iterator/transform_iterator.hpp:96:21,
+#     inlined from ‘boost::iterators::transform_iterator<UnaryFunc, Iterator> boost::iterators::make_transform_iterator(Iterator, UnaryFunc) [with UnaryFunc = std::function<const fuse_core::Variable&(const std::pair<const boost::uuids::uuid, std::shared_ptr<fuse_core::Variable> >&)>; Iterator = std::__detail::_Node_const_iterator<std::pair<const boost::uuids::uuid, std::shared_ptr<fuse_core::Variable> >, false, true>]’ at include/boost/iterator/transform_iterator.hpp:141:61,
+#     inlined from ‘virtual fuse_core::Graph::const_variable_range fuse_graphs::HashGraph::getVariables() const’ at fuse/fuse_graphs/src/hash_graph.cpp:284:35:
+# /nix/store/b7hvml0m3qmqraz1022fwvyyg6fc1vdy-gcc-12.2.0/include/c++/12.2.0/bits/std_function.h:391:17: error: ‘<anonymous>’ may be used uninitialized [-Werror=maybe-uninitialized]
+#   391 |             __x._M_manager(_M_functor, __x._M_functor, __clone_functor);
+#       |             ~~~~^~~~~~~~~~
+# /nix/store/b7hvml0m3qmqraz1022fwvyyg6fc1vdy-gcc-12.2.0/include/c++/12.2.0/bits/std_function.h: In member function ‘virtual fuse_core::Graph::const_variable_range fuse_graphs::HashGraph::getVariables() const’:
+# /nix/store/b7hvml0m3qmqraz1022fwvyyg6fc1vdy-gcc-12.2.0/include/c++/12.2.0/bits/std_function.h:267:7: note: by argument 2 of type ‘const std::_Any_data&’ to ‘static bool std::_Function_handler<_Res(_ArgTypes ...), _Functor>::_M_manager(std::_Any_data&, const std::_Any_data&, std::_Manager_operation) [with _Res = const fuse_core::Variable&; _Functor = fuse_graphs::HashGraph::getVariables() const::<lambda(const std::unordered_map<boost::uuids::uuid, std::shared_ptr<fuse_core::Variable>, boost::hash<boost::uuids::uuid> >::value_type&)>; _ArgTypes = {const std::pair<const boost::uuids::uuid, std::shared_ptr<fuse_core::Variable> >&}]’ declared here
+#   267 |       _M_manager(_Any_data& __dest, const _Any_data& __source,
+#       |       ^~~~~~~~~~
+add_compile_options(-Wall -Werror -Wno-maybe-uninitialized)
 
 ## fuse_graphs library
 add_library(${PROJECT_NAME}

--- a/fuse_graphs/include/fuse_graphs/hash_graph.h
+++ b/fuse_graphs/include/fuse_graphs/hash_graph.h
@@ -34,6 +34,7 @@
 #ifndef FUSE_GRAPHS_HASH_GRAPH_H
 #define FUSE_GRAPHS_HASH_GRAPH_H
 
+#include <fuse_core/ceres_macros.h>
 #include <fuse_core/constraint.h>
 #include <fuse_core/graph.h>
 #include <fuse_core/fuse_macros.h>
@@ -423,7 +424,15 @@ void serialize(Archive& archive, ceres::Problem::Options& options, const unsigne
   archive & options.cost_function_ownership;
   archive & options.disable_all_safety_checks;
   archive & options.enable_fast_removal;
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  // Local parameterizations got marked as deprecated in favour of Manifold in version 2.1.0, see
+  // https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc
+  // and they got removed in 2.2.0, see
+  // https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3
+  archive & options.manifold_ownership;
+#else
   archive & options.local_parameterization_ownership;
+#endif
   archive & options.loss_function_ownership;
 }
 

--- a/fuse_loss/CMakeLists.txt
+++ b/fuse_loss/CMakeLists.txt
@@ -49,6 +49,9 @@ add_library(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     include
+)
+target_include_directories(${PROJECT_NAME}
+  SYSTEM PUBLIC
     ${catkin_INCLUDE_DIRS}
     ${CERES_INCLUDE_DIRS}
 )

--- a/fuse_models/test/test_unicycle_2d_state_cost_function.cpp
+++ b/fuse_models/test/test_unicycle_2d_state_cost_function.cpp
@@ -31,6 +31,8 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fuse_core/ceres_macros.h>
+
 #include <fuse_models/unicycle_2d_state_cost_function.h>
 #include <fuse_models/unicycle_2d_state_cost_functor.h>
 
@@ -99,7 +101,13 @@ TEST(CostFunction, evaluateCostFunction)
 
   // Check jacobians are correct using a gradient checker
   ceres::NumericDiffOptions numeric_diff_options;
-  ceres::GradientChecker gradient_checker(&cost_function, NULL, numeric_diff_options);
+  ceres::GradientChecker gradient_checker(&cost_function,
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+      static_cast<const std::vector<const ceres::Manifold*>*>(nullptr),
+#else
+      static_cast<const std::vector<const ceres::LocalParameterization*>*>(nullptr),
+#endif
+      numeric_diff_options);
 
   // We cannot use std::numeric_limits<double>::epsilon() tolerance because the worst relative error is 5.26356e-10
   ceres::GradientChecker::ProbeResults probe_results;

--- a/fuse_variables/CMakeLists.txt
+++ b/fuse_variables/CMakeLists.txt
@@ -54,6 +54,9 @@ add_dependencies(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     include
+)
+target_include_directories(${PROJECT_NAME}
+  SYSTEM PUBLIC
     ${catkin_INCLUDE_DIRS}
     ${CERES_INCLUDE_DIRS}
 )

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -63,12 +63,20 @@ namespace fuse_variables
 class Orientation2DLocalParameterization : public fuse_core::LocalParameterization
 {
 public:
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  int AmbientSize() const override
+#else
   int GlobalSize() const override
+#endif
   {
     return 1;
   }
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  int TangentSize() const override
+#else
   int LocalSize() const override
+#endif
   {
     return 1;
   }
@@ -83,7 +91,11 @@ public:
     return true;
   }
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  bool PlusJacobian(
+#else
   bool ComputeJacobian(
+#endif
     const double* /*x*/,
     double* jacobian) const override
   {
@@ -101,7 +113,11 @@ public:
     return true;
   }
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  bool MinusJacobian(
+#else
   bool ComputeMinusJacobian(
+#endif
     const double* /*x*/,
     double* jacobian) const override
   {

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -121,7 +121,7 @@ public:
     const double* /*x*/,
     double* jacobian) const override
   {
-    jacobian[0] = 1.0;
+    jacobian[0] = -1.0;
     return true;
   }
 

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -53,6 +53,7 @@
 namespace fuse_variables
 {
 
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 /**
  * @brief A LocalParameterization class for 2D Orientations.
  *
@@ -142,6 +143,85 @@ private:
   }
 };
 
+#endif
+
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+/**
+ * @brief A Manifold class for 2D Orientations.
+ *
+ * 2D orientations add and subtract in the "usual" way, except for the 2*pi rollover issue. This local parameterization
+ * handles the rollover. Because the Jacobians for this parameterization are always identity, we implement this
+ * parameterization with "analytic" derivatives, instead of using the Ceres's autodiff system.
+ */
+class Orientation2DManifold : public fuse_core::Manifold
+{
+public:
+  int AmbientSize() const override
+  {
+    return 1;
+  }
+
+  int TangentSize() const override
+  {
+    return 1;
+  }
+
+  bool Plus(
+    const double* x,
+    const double* delta,
+    double* x_plus_delta) const override
+  {
+    // Compute the angle increment as a linear update, and handle the 2*Pi rollover
+    x_plus_delta[0] = fuse_core::wrapAngle2D(x[0] + delta[0]);
+    return true;
+  }
+
+  bool PlusJacobian(
+    const double* /*x*/,
+    double* jacobian) const override
+  {
+    jacobian[0] = 1.0;
+    return true;
+  }
+
+  bool Minus(
+    const double* y,
+    const double* x,
+    double* y_minus_x) const override
+  {
+    // Compute the difference from x2 to x1, and handle the 2*Pi rollover
+    y_minus_x[0] = fuse_core::wrapAngle2D(x2[0] - x1[0]);
+    return true;
+  }
+
+  bool MinusJacobian(
+    const double* /*x*/,
+    double* jacobian) const override
+  {
+    jacobian[0] = -1.0;
+    return true;
+  }
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Manifold>(*this);
+  }
+};
+
+#endif
+
 /**
  * @brief Variable representing a 2D orientation (theta) at a specific time, with a specific piece of hardware.
  *
@@ -199,6 +279,7 @@ public:
    */
   size_t localSize() const override { return 1u; }
 
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
   /**
    * @brief Create a new Ceres local parameterization object to apply to updates of this variable
    *
@@ -208,6 +289,19 @@ public:
    * @return A base pointer to an instance of a derived LocalParameterization
    */
   fuse_core::LocalParameterization* localParameterization() const override;
+#endif
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  /**
+   * @brief Create a new Ceres manifold object to apply to updates of this variable
+   *
+   * A 2D rotation has a nonlinearity when the angle wraps around from -PI to PI. This is handled by a custom
+   * manifold to ensure smooth derivatives.
+   *
+   * @return A base pointer to an instance of a derived manifold
+   */
+  fuse_core::Manifold* manifold() const override;
+#endif
 
 private:
   // Allow Boost Serialization access to private methods
@@ -229,7 +323,14 @@ private:
 
 }  // namespace fuse_variables
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation2DManifold);
+#endif 
+
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation2DLocalParameterization);
+#endif
+
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation2DStamped);
 
 #endif  // FUSE_VARIABLES_ORIENTATION_2D_STAMPED_H

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -78,12 +78,20 @@ public:
     out[3] = -in[3];
   }
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  int AmbientSize() const override
+#else
   int GlobalSize() const override
+#endif
   {
     return 4;
   }
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  int TangentSize() const override
+#else
   int LocalSize() const override
+#endif
   {
     return 3;
   }
@@ -99,7 +107,11 @@ public:
     return true;
 }
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  bool PlusJacobian(
+#else
   bool ComputeJacobian(
+#endif
     const double* x,
     double* jacobian) const override
   {
@@ -127,7 +139,11 @@ public:
     return true;
   }
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  bool MinusJacobian(
+#else
   bool ComputeMinusJacobian(
+#endif
     const double* x,
     double* jacobian) const override
   {

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -151,9 +151,9 @@ public:
     double x1 = x[1] * 2;
     double x2 = x[2] * 2;
     double x3 = x[3] * 2;
-    jacobian[0] = -x1; jacobian[1]  =  x0; jacobian[2]  =  x3;  jacobian[3]  = -x2;  // NOLINT
-    jacobian[4] = -x2; jacobian[5]  = -x3; jacobian[6]  =  x0;  jacobian[7]  =  x1;  // NOLINT
-    jacobian[8] = -x3; jacobian[9]  =  x2; jacobian[10] = -x1;  jacobian[11] =  x0;  // NOLINT
+    jacobian[0] = x1; jacobian[1]  = -x0; jacobian[2]  = -x3;  jacobian[3]  =  x2;  // NOLINT
+    jacobian[4] = x2; jacobian[5]  =  x3; jacobian[6]  = -x0;  jacobian[7]  = -x1;  // NOLINT
+    jacobian[8] = x3; jacobian[9]  = -x2; jacobian[10] =  x1;  jacobian[11] = -x0;  // NOLINT
     return true;
   }
 

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -54,6 +54,7 @@
 namespace fuse_variables
 {
 
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 /**
  * @brief A LocalParameterization class for 3D Orientations.
  *
@@ -173,6 +174,100 @@ private:
     archive & boost::serialization::base_object<fuse_core::LocalParameterization>(*this);
   }
 };
+#endif
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+/**
+ * @brief A Manifold class for 2D Orientations.
+ *
+ * 2D orientations add and subtract in the "usual" way, except for the 2*pi rollover issue. This local parameterization
+ * handles the rollover. Because the Jacobians for this parameterization are always identity, we implement this
+ * parameterization with "analytic" derivatives, instead of using the Ceres's autodiff system.
+ */
+class Orientation3DManifold : public fuse_core::Manifold
+{
+public:
+  int AmbientSize() const override
+  {
+    return 4;
+  }
+
+  int TangentSize() const override
+  {
+    return 3;
+  }
+
+  bool Plus(
+    const double* x,
+    const double* delta,
+    double* x_plus_delta) const override
+  {
+    double q_delta[4];
+    ceres::AngleAxisToQuaternion(delta, q_delta);
+    ceres::QuaternionProduct(x, q_delta, x_plus_delta);
+    return true;
+  }
+
+  bool PlusJacobian(
+    const double* /*x*/,
+    double* jacobian) const override
+  {
+    double x0 = x[0] / 2;
+    double x1 = x[1] / 2;
+    double x2 = x[2] / 2;
+    double x3 = x[3] / 2;
+    jacobian[0] = -x1; jacobian[1]  = -x2; jacobian[2]  = -x3;  // NOLINT
+    jacobian[3] =  x0; jacobian[4]  = -x3; jacobian[5]  =  x2;  // NOLINT
+    jacobian[6] =  x3; jacobian[7]  =  x0; jacobian[8]  = -x1;  // NOLINT
+    jacobian[9] = -x2; jacobian[10] =  x1; jacobian[11] =  x0;  // NOLINT
+    return true;
+  }
+
+  bool Minus(
+    const double* y,
+    const double* x,
+    double* y_minus_x) const override
+  {
+    double x_inverse[4];
+    QuaternionInverse(x, x_inverse);
+    double q_delta[4];
+    ceres::QuaternionProduct(x_inverse, y, q_delta);
+    ceres::QuaternionToAngleAxis(q_delta, y_minus_x);
+    return true;
+  }
+
+  bool MinusJacobian(
+    const double* /*x*/,
+    double* jacobian) const override
+  {
+    double x0 = x[0] * 2;
+    double x1 = x[1] * 2;
+    double x2 = x[2] * 2;
+    double x3 = x[3] * 2;
+    jacobian[0] = x1; jacobian[1]  = -x0; jacobian[2]  = -x3;  jacobian[3]  =  x2;  // NOLINT
+    jacobian[4] = x2; jacobian[5]  =  x3; jacobian[6]  = -x0;  jacobian[7]  = -x1;  // NOLINT
+    jacobian[8] = x3; jacobian[9]  = -x2; jacobian[10] =  x1;  jacobian[11] = -x0;  // NOLINT
+    return true;
+  }
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class members
+   * @param[in] version - The version of the archive being read/written. Generally unused.
+   */
+  template<class Archive>
+  void serialize(Archive& archive, const unsigned int /* version */)
+  {
+    archive & boost::serialization::base_object<fuse_core::Manifold>(*this);
+  }
+};
+
+#endif
 
 /**
  * @brief Variable representing a 3D orientation as a quaternion at a specific time and for a specific piece of
@@ -294,12 +389,24 @@ public:
    */
   size_t localSize() const override { return 3u; }
 
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
   /**
    * @brief Provides a Ceres local parameterization for the quaternion
    *
    * @return A pointer to a local parameterization object that indicates how to "add" increments to the quaternion
    */
   fuse_core::LocalParameterization* localParameterization() const override;
+#endif
+
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+  /**
+   * @brief Provides a Ceres manifold for the quaternion
+   *
+   * @return A pointer to a manifold object that indicates how to "add" increments to the quaternion
+   */
+  fuse_core::Manifold* manifold() const override;
+#endif
 
 private:
   // Allow Boost Serialization access to private methods
@@ -321,7 +428,14 @@ private:
 
 }  // namespace fuse_variables
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation3DManifold);
+#endif
+
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation3DLocalParameterization);
+#endif
+
 BOOST_CLASS_EXPORT_KEY(fuse_variables::Orientation3DStamped);
 
 #endif  // FUSE_VARIABLES_ORIENTATION_3D_STAMPED_H

--- a/fuse_variables/src/orientation_3d_stamped.cpp
+++ b/fuse_variables/src/orientation_3d_stamped.cpp
@@ -69,13 +69,29 @@ void Orientation3DStamped::print(std::ostream& stream) const
          << "  - z: " << z() << "\n";
 }
 
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 fuse_core::LocalParameterization* Orientation3DStamped::localParameterization() const
 {
   return new Orientation3DLocalParameterization();
 }
+#endif
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+fuse_core::Manifold* Orientation3DStamped::manifold() const
+{
+  return new Orientation3DManifold();
+}
+#endif
 
 }  // namespace fuse_variables
 
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DManifold);
+#endif
+
+#if !CERES_VERSION_AT_LEAST(2, 2, 0)
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DLocalParameterization);
+#endif
+
 BOOST_CLASS_EXPORT_IMPLEMENT(fuse_variables::Orientation3DStamped);
 PLUGINLIB_EXPORT_CLASS(fuse_variables::Orientation3DStamped, fuse_core::Variable);

--- a/fuse_variables/test/test_point_2d_fixed_landmark.cpp
+++ b/fuse_variables/test/test_point_2d_fixed_landmark.cpp
@@ -78,7 +78,6 @@ struct CostFunctor
   {
     residual[0] = x[0] - T(3.0);
     residual[1] = x[1] + T(8.0);
-    residual[2] = x[2] - T(3.1);
     return true;
   }
 };


### PR DESCRIPTION
Use `ceres::Manifold` instead of `ceres::LocalParameterization`, which was marked as deprecated in Ceres 2.1.0, and removed in 2.2.0.

This also fixes or ignores some warnings that happened with gcc 12, which includes a gcc 12 bug and a bug in a unit test.

I built all `fuse` packages successfully with these changes:
```bash
nix develop clearpath/2.32.0-20231004045951-SES-4299-0#sdk
colcon build --mixin ws-test --packages-select fuse_graphs fuse_core fuse_constraints fuse_variables fuse_loss fuse_msgs fuse_models fuse_viz fuse_publishers fuse_optimizers fuse_doc fuse_tutorials
```

All tests passed successfully:
```bash
colcon test --event-handlers console_direct+ --packages-select fuse_graphs fuse_core fuse_constraints fuse_variables fuse_loss fuse_msgs fuse_models fuse_viz fuse_publishers fuse_optimizers fuse_doc fuse_tutorials
```

:point_right: But I found a bug in the local parameterization for the 2D and 3D orientation, which were computing the jacobian for the wrong variable. The autodiff implementation was also wrong, hiding the error. The implementation in the new autodiff manifold is different. I've highlighted that with a comment in that code. This could indeed be a serious bug with broad implications.

I'll send a similar MR upstream.