### PR TITLE
SES 4299 manifold refactor

### DIFF
--- a/fuse_constraints/src/marginal_cost_function.cpp
+++ b/fuse_constraints/src/marginal_cost_function.cpp
@@ -98,13 +98,8 @@ bool MarginalCostFunction::Evaluate(
         if (local_parameterizations_[i])
         {
           const auto& local_parameterization = local_parameterizations_[i];
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-          fuse_core::MatrixXd J_local(local_parameterization->TangentSize(), local_parameterization->AmbientSize());
-          local_parameterization->MinusJacobian(parameters[i], J_local.data());
-#else
           fuse_core::MatrixXd J_local(local_parameterization->LocalSize(), local_parameterization->GlobalSize());
           local_parameterization->ComputeMinusJacobian(parameters[i], J_local.data());
-#endif
           Eigen::Map<fuse_core::MatrixXd>(jacobians[i], num_residuals(), parameter_block_sizes()[i]) = A_[i] * J_local;
         }
         else

--- a/fuse_constraints/src/marginalize_variables.cpp
+++ b/fuse_constraints/src/marginalize_variables.cpp
@@ -343,23 +343,14 @@ LinearTerm linearize(
     {
       if (local_parameterization)
       {
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-        jacobian.resize(Eigen::NoChange, local_parameterization->TangentSize());
-#else
         jacobian.resize(Eigen::NoChange, local_parameterization->LocalSize());
-#endif
       }
       jacobian.setZero();
     }
     else if (local_parameterization)
     {
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-      fuse_core::MatrixXd J(local_parameterization->AmbientSize(), local_parameterization->TangentSize());
-      local_parameterization->PlusJacobian(variable_values[index], J.data());
-#else
       fuse_core::MatrixXd J(local_parameterization->GlobalSize(), local_parameterization->LocalSize());
       local_parameterization->ComputeJacobian(variable_values[index], J.data());
-#endif
       jacobian *= J;
     }
     if (local_parameterization)

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -45,7 +45,7 @@
 // https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc
 // and they got removed in 2.2.0, see
 // https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3
-#include <ceres/manifold.h>
+#include <fuse_core/manifold.h>
 #else
 #include <ceres/local_parameterization.h>
 #endif
@@ -66,7 +66,7 @@ namespace fuse_core
  */
 class LocalParameterization : public
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
-                              ceres::Manifold
+                              fuse::Manifold
 #else
                               ceres::LocalParameterization
 #endif

--- a/fuse_core/include/fuse_core/local_parameterization.h
+++ b/fuse_core/include/fuse_core/local_parameterization.h
@@ -66,7 +66,7 @@ namespace fuse_core
  */
 class LocalParameterization : public
 #if CERES_VERSION_AT_LEAST(2, 1, 0)
-                              fuse::Manifold
+                              fuse_core::Manifold
 #else
                               ceres::LocalParameterization
 #endif

--- a/fuse_core/include/fuse_core/manifold.h
+++ b/fuse_core/include/fuse_core/manifold.h
@@ -73,7 +73,7 @@ public:
    * @return True if successful, false otherwise
    */
   virtual bool Plus(const double *x, const double *delta,
-                    double *x_plus_delta) const override = 0;
+                    double *x_plus_delta) const = 0;
 
   /**
    * @brief The jacobian of Plus(x, delta) w.r.t delta at delta = 0.
@@ -84,7 +84,7 @@ public:
    * @return True if successful, false otherwise
    */
   virtual bool ComputeJacobian(const double *x,
-                               double *jacobian) const override = 0;
+                               double *jacobian) const = 0;
 
   /**
    * @brief Generalization of the subtraction operation
@@ -102,7 +102,7 @@ public:
    * @return True if successful, false otherwise
    */
   virtual bool Minus(const double *x2, const double *x1,
-                     double *x2_minus_x1) const override = 0;
+                     double *x2_minus_x1) const = 0;
 
   /**
    * @brief The jacobian of Minus(x1, x2) w.r.t x2 at x1 == x2 == x
@@ -114,23 +114,23 @@ public:
    * @return True if successful, false otherwise
    */
   virtual bool ComputeMinusJacobian(const double *x,
-                                    double *jacobian) const override = 0;
+                                    double *jacobian) const = 0;
 
   // Size of x.
-  virtual int GlobalSize() const override = 0;
+  virtual int GlobalSize() const = 0;
   // Size of delta.
-  virtual int LocalSize() const override = 0;
+  virtual int LocalSize() const = 0;
 
 protected:
   /// Equivalent to \p GlobalSize()
   int AmbientSize() const override { return GlobalSize(); }
 
   /// Equivalent to \p LocalSize()
-  int TangentSize() const override { return TangetSize(); }
+  int TangentSize() const override { return LocalSize(); }
 
   /// Equivalent to \p ComputeJacobian()
   bool PlusJacobian(const double *x, double *jacobian) const override {
-    return ComputeJacobian(c, jacobian);
+    return ComputeJacobian(x, jacobian);
   }
 
   /// Equivalent to \p ComputeMinusJacobian()

--- a/fuse_core/include/fuse_core/manifold.h
+++ b/fuse_core/include/fuse_core/manifold.h
@@ -1,0 +1,162 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef FUSE_CORE_MANIFOLD_H
+#define FUSE_CORE_MANIFOLD_H
+
+#include <fuse_core/ceres_macros.h>
+#include <fuse_core/fuse_macros.h>
+#include <fuse_core/serialization.h>
+
+#include <boost/serialization/access.hpp>
+
+#if CERES_VERSION_AT_LEAST(2, 1, 0)
+// Local parameterizations got marked as deprecated in favour of Manifold in
+// version 2.1.0, see
+// https://github.com/ceres-solver/ceres-solver/commit/0141ca090c315db2f3c38e1731f0fe9754a4e4cc
+// and they got removed in 2.2.0, see
+// https://github.com/ceres-solver/ceres-solver/commit/68c53bb39552cd4abfd6381df08638285f7386b3
+#include <ceres/manifold.h>
+
+namespace fuse_core {
+
+/**
+ * @brief The Manifold interface definition.
+ *
+ * This class extends the Ceres Manifold class but adds methods to match the
+ * fuse::LocalParameterization API
+ *
+ * See the Ceres documentation for more details.
+ * http://ceres-solver.org/nnls_modeling.html#manifold
+ */
+class Manifold : public ceres::Manifold {
+public:
+  FUSE_SMART_PTR_ALIASES_ONLY(Manifold);
+
+  /**
+   * @brief Generalization of the addition operation, with the condition that
+   * Plus(x, 0) = x
+   *
+   * @param[in] x    The value of the first variable, of size \p GlobalSize()
+   * @param[in] delta The value of the perturbation, of size \p LocalSize()
+   * @param[out] x_plus_delta Perturbed x, of size \p GlobalSize()
+   * @return True if successful, false otherwise
+   */
+  virtual bool Plus(const double *x, const double *delta,
+                    double *x_plus_delta) const override = 0;
+
+  /**
+   * @brief The jacobian of Plus(x, delta) w.r.t delta at delta = 0.
+   *
+   * @param[in] x    The value of the first variable, of size \p GlobalSize()
+   * @param[out] jacobian Jacobian is a row-major GlobalSize() x LocalSize()
+   * matrix.
+   * @return True if successful, false otherwise
+   */
+  virtual bool ComputeJacobian(const double *x,
+                               double *jacobian) const override = 0;
+
+  /**
+   * @brief Generalization of the subtraction operation
+   *
+   * Minus(x2, x1) -> x2_minus_x1
+   *
+   * with the conditions that:
+   *  - Minus(x, x) -> 0
+   *  - if Plus(x1, delta) -> x2, then Minus(x2, x1) -> delta
+   *
+   * @param[in]  x2    The value of the first variable, of size \p GlobalSize()
+   * @param[in]  x1    The value of the second variable, of size \p GlobalSize()
+   * @param[out] x2_minus_x1 The difference between x2 and x1, of size \p
+   * LocalSize()
+   * @return True if successful, false otherwise
+   */
+  virtual bool Minus(const double *x2, const double *x1,
+                     double *x2_minus_x1) const override = 0;
+
+  /**
+   * @brief The jacobian of Minus(x1, x2) w.r.t x2 at x1 == x2 == x
+   *
+   * @param[in]  x        The value used to evaluate the Jacobian, of size \p
+   * GlobalSize()
+   * @param[out] jacobian The first-order derivative in row-major order, of size
+   * \p LocalSize() x \p GlobalSize()
+   * @return True if successful, false otherwise
+   */
+  virtual bool ComputeMinusJacobian(const double *x,
+                                    double *jacobian) const override = 0;
+
+  // Size of x.
+  virtual int GlobalSize() const override = 0;
+  // Size of delta.
+  virtual int LocalSize() const override = 0;
+
+protected:
+  /// Equivalent to \p GlobalSize()
+  int AmbientSize() const override { return GlobalSize(); }
+
+  /// Equivalent to \p LocalSize()
+  int TangentSize() const override { return TangetSize(); }
+
+  /// Equivalent to \p ComputeJacobian()
+  bool PlusJacobian(const double *x, double *jacobian) const override {
+    return ComputeJacobian(c, jacobian);
+  }
+
+  /// Equivalent to \p ComputeMinusJacobian()
+  bool MinusJacobian(const double *x, double *jacobian) const override {
+    return ComputeMinusJacobian(x, jacobian);
+  }
+
+private:
+  // Allow Boost Serialization access to private methods
+  friend class boost::serialization::access;
+
+  /**
+   * @brief The Boost Serialize method that serializes all of the data members
+   * in to/out of the archive
+   *
+   * @param[in/out] archive - The archive object that holds the serialized class
+   * members
+   * @param[in] version - The version of the archive being read/written.
+   * Generally unused.
+   */
+  template <class Archive>
+  void serialize(Archive & /* archive */, const unsigned int /* version */) {}
+};
+
+} // namespace fuse_core
+
+#endif
+
+#endif // FUSE_CORE_MANIFOLD_H

--- a/fuse_core/include/fuse_core/manifold.h
+++ b/fuse_core/include/fuse_core/manifold.h
@@ -1,7 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2019, Locus Robotics
+ *  Copyright (c) 2024, Clearpath Robotics
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -121,7 +121,6 @@ public:
   // Size of delta.
   virtual int LocalSize() const = 0;
 
-protected:
   /// Equivalent to \p GlobalSize()
   int AmbientSize() const override { return GlobalSize(); }
 

--- a/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_2d_stamped.h
@@ -63,20 +63,12 @@ namespace fuse_variables
 class Orientation2DLocalParameterization : public fuse_core::LocalParameterization
 {
 public:
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  int AmbientSize() const override
-#else
   int GlobalSize() const override
-#endif
   {
     return 1;
   }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  int TangentSize() const override
-#else
   int LocalSize() const override
-#endif
   {
     return 1;
   }
@@ -91,11 +83,7 @@ public:
     return true;
   }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  bool PlusJacobian(
-#else
   bool ComputeJacobian(
-#endif
     const double* /*x*/,
     double* jacobian) const override
   {
@@ -113,11 +101,7 @@ public:
     return true;
   }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  bool MinusJacobian(
-#else
   bool ComputeMinusJacobian(
-#endif
     const double* /*x*/,
     double* jacobian) const override
   {

--- a/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
+++ b/fuse_variables/include/fuse_variables/orientation_3d_stamped.h
@@ -78,20 +78,12 @@ public:
     out[3] = -in[3];
   }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  int AmbientSize() const override
-#else
   int GlobalSize() const override
-#endif
   {
     return 4;
   }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  int TangentSize() const override
-#else
   int LocalSize() const override
-#endif
   {
     return 3;
   }
@@ -105,13 +97,9 @@ public:
     ceres::AngleAxisToQuaternion(delta, q_delta);
     ceres::QuaternionProduct(x, q_delta, x_plus_delta);
     return true;
-}
+  }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  bool PlusJacobian(
-#else
   bool ComputeJacobian(
-#endif
     const double* x,
     double* jacobian) const override
   {
@@ -139,11 +127,7 @@ public:
     return true;
   }
 
-#if CERES_VERSION_AT_LEAST(2, 1, 0)
-  bool MinusJacobian(
-#else
   bool ComputeMinusJacobian(
-#endif
     const double* x,
     double* jacobian) const override
   {


### PR DESCRIPTION
Updated the code to keep the same API that the original fuse LocalParameterization had, while still supporting the new fuse manifold