### PR TITLE
More deterministic throttling

### DIFF
--- a/fuse_core/include/fuse_core/throttled_callback.h
+++ b/fuse_core/include/fuse_core/throttled_callback.h
@@ -145,38 +145,17 @@ public:
   /**
    * @brief Callback that throttles the calls to the keep callback provided. When dropped because
    * of throttling, the drop callback is called instead.
+   * @details The decision to throttle is made using ros::Time::now when use_wall_time_ is false and ros::WallTime::now
+   * when it is true. The first message after the most recent whole-number multiple of the throttle_period_ is published
+   * and all others are dropped.
    *
    * @param[in] args The input arguments
    */
   template <class... Args>
   void callback(Args&&... args)
   {
-    // Keep the callback if:
-    //
-    // (a) This is the first call, i.e. the last called time is still invalid because it has not been set yet
-    // (b) The throttle period is zero, so we should always keep the callbacks
-    // (c) The elpased time between now and the last called time is greater than the throttle period
     const ros::Time now = use_wall_time_ ? ros::Time(ros::WallTime::now().toSec()) : ros::Time::now();
-    if (last_called_time_.isZero() || throttle_period_.isZero() || now - last_called_time_ > throttle_period_)
-    {
-      if (keep_callback_)
-      {
-        keep_callback_(std::forward<Args>(args)...);
-      }
-
-      if (last_called_time_.isZero())
-      {
-        last_called_time_ = now;
-      }
-      else
-      {
-        last_called_time_ += throttle_period_;
-      }
-    }
-    else if (drop_callback_)
-    {
-      drop_callback_(std::forward<Args>(args)...);
-    }
+    callbackImpl(now, std::forward<Args>(args)...);
   }
 
   /**
@@ -190,22 +169,156 @@ public:
     callback(std::forward<Args>(args)...);
   }
 
-private:
-  Callback keep_callback_;         //!< The callback to call when kept, i.e. not dropped
-  Callback drop_callback_;         //!< The callback to call when dropped because of throttling
-  ros::Duration throttle_period_;  //!< The throttling period duration in seconds
-  bool use_wall_time_;             //<! The flag to indicate whether to use ros::WallTime or not
+protected:
+  /**
+   * @brief The implementation of the throttled callback
+   *
+   * @param[in] time The time used for throttling
+   * @param[in] args The input arguments
+   */
+  template <class... Args>
+  void callbackImpl(const ros::Time& time, Args&&... args)
+  {
+    // Keep the callback if:
+    //
+    // (a) The throttle period is zero, so we should always keep the callbacks
+    // (b) The time is past the next whole number multiple of the throttle period
+    //  If this is the first time this has been called, just store what the most recent phase-aligned publish time
+    //  would have been so we know the next publish time.
+    bool keep = false;
+    if (throttle_period_.isZero())
+    {
+      keep = true;
+    }
+    else if (!last_called_time_set_ || time > last_called_time_ + throttle_period_)
+    {
+      if (last_called_time_set_)
+      {
+        keep = true;
+      }
 
-  ros::Time last_called_time_;  //!< The last time the keep callback was called
+      // Use the nearest phase-aligned multiple of the throttle period as our reference time to improve determinism
+      const double time_s = time.toSec();
+      const double last_called_time_s =  time_s - std::fmod(time_s, throttle_period_.toSec());
+      last_called_time_.fromSec(last_called_time_s);
+      last_called_time_set_ = true;
+    }
+
+    if (keep)
+    {
+      if (keep_callback_)
+      {
+        keep_callback_(std::forward<Args>(args)...);
+      }
+    }
+    else if (drop_callback_)
+    {
+      drop_callback_(std::forward<Args>(args)...);
+    }
+  }
+
+  Callback keep_callback_;            //!< The callback to call when kept, i.e. not dropped
+  Callback drop_callback_;            //!< The callback to call when dropped because of throttling
+  ros::Duration throttle_period_;     //!< The throttling period duration in seconds
+  bool use_wall_time_;                //<! The flag to indicate whether to use ros::WallTime or not
+  bool last_called_time_set_{false};  //<! The flag to indicate whether the last called time has been set
+  ros::Time last_called_time_;        //!< The last time the keep callback was called
 };
 
 /**
- * @brief Throttled callback for ROS messages
+ * @brief Throttled callback for ROS messages, option to throttle using header timestamps with `message_stamp_callback`
  *
  * @tparam M The ROS message type, which should have the M::ConstPtr nested type
  */
 template <class M>
-using ThrottledMessageCallback = ThrottledCallback<std::function<void(const typename M::ConstPtr&)>>;
+class ThrottledMessageCallback : public ThrottledCallback<std::function<void(const typename M::ConstPtr&)>>
+{
+public:
+  using Callback = std::function<void(const typename M::ConstPtr&)>;
+
+  ThrottledMessageCallback(Callback&& keep_callback = nullptr,  // NOLINT(whitespace/operators)
+                           Callback&& drop_callback = nullptr,  // NOLINT(whitespace/operators)
+                           const ros::Duration& throttle_period = ros::Duration(0.0),
+                           const bool use_wall_time = false,
+                           const bool use_header_timestamps = false)
+    : ThrottledCallback<Callback>(std::move(keep_callback), std::move(drop_callback), throttle_period,
+                                  use_wall_time), use_header_timestamps_(use_header_timestamps)
+    {
+      if (use_wall_time && use_header_timestamps)
+      {
+        throw std::runtime_error("Cannot specify both wall time and header timestamps for callback throttling."
+                                 " Use only one.");
+      }
+    }
+
+ /**
+ * @brief Callback that selects the correct timestamp to throttle the calls to the keep callback provided based
+ * the configuration arguments.
+ *
+ * @param[in] args The callback args, will be forwarded to the callback
+ */
+  template <class... Args>
+  void callback(Args&&... args)
+  {
+    if (use_header_timestamps_)
+    {
+      messageStampCallback(std::forward<Args>(args)...);
+    }
+    else
+    {
+      // Use base-class version
+      ThrottledCallback<Callback>::callback(std::forward<Args>(args)...);
+    }
+  }
+
+  /**
+   * @brief Operator() that simply calls the callback() method forwarding the input arguments
+   * @note Needs to be duplicated because virtual templates are not allowed
+   *
+   * @param[in] args The input arguments
+   */
+  template <class... Args>
+  void operator()(Args&&... args)
+  {
+    callback(std::forward<Args>(args)...);
+  }
+
+
+  /**
+   * @brief Callback that uses message header timestamps to throttle the calls to the keep callback provided.
+   * When dropped because of throttling, the drop callback is called instead.
+   * @details The first message after the most recent whole-number multiple of the throttle_period_ is published
+   * and all others are dropped.
+   *
+   * @param[in] msg The message to be throttled
+   */
+  template <typename = typename std::enable_if_t<ros::message_traits::HasHeader<M>::value>>
+  void messageStampCallback(const typename M::ConstPtr& msg)
+  {
+    const ros::Time msg_stamp_time(msg->header.stamp.sec, msg->header.stamp.nsec);
+    this->callbackImpl(msg_stamp_time, msg);
+  }
+
+  /**
+   * @brief Use header timestamps flag setter
+   *
+   * @param[in] use_header_timestamps Whether to use msg header timestamps or not
+   */
+  void setUseHeaderTimestamps(const bool use_header_timestamps)
+  {
+    if (use_header_timestamps && this->use_wall_time_)
+    {
+      throw std::runtime_error("Cannot specify both wall time and header timestamps for callback throttling."
+                               " Use only one.");
+    }
+    use_header_timestamps_ = use_header_timestamps;
+  }
+
+protected:
+  bool use_header_timestamps_{ false };  //<! Whether to use message header timestamps or current time
+};
+
+
 
 }  // namespace fuse_core
 

--- a/fuse_core/test/test_throttled_callback.cpp
+++ b/fuse_core/test/test_throttled_callback.cpp
@@ -32,16 +32,16 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <fuse_core/throttled_callback.h>
-#include <geometry_msgs/Point.h>
+#include <geometry_msgs/PointStamped.h>
 #include <ros/ros.h>
 
 #include <gtest/gtest.h>
 
 
 /**
- * @brief A helper class to publish a given number geometry_msgs::Point messages at a given frequency.
+ * @brief A helper class to publish a given number geometry_msgs::PointStamped messages at a given frequency.
  *
- * The messages published are geometry_msgs::Point because it is simple. The 'x' field is set to the number of messages
+ * The messages published are geometry_msgs::PointStamped because it is simple. The 'x' field is set to the number of messages
  * published so far, starting at 0.
  */
 class PointPublisher
@@ -55,7 +55,7 @@ public:
   explicit PointPublisher(const double frequency)
     : frequency_(frequency)
   {
-    publisher_ = node_handle_.advertise<geometry_msgs::Point>("point", 1);
+    publisher_ = node_handle_.advertise<geometry_msgs::PointStamped>("point", 1);
   }
 
   /**
@@ -66,7 +66,7 @@ public:
   void publish(const size_t num_messages)
   {
     // Wait for the subscribers to be ready before sending them data:
-    ros::WallTime subscriber_timeout = ros::WallTime::now() + ros::WallDuration(1.0);
+    const ros::WallTime subscriber_timeout = ros::WallTime::now() + ros::WallDuration(1.0);
     while (publisher_.getNumSubscribers() < 1u && ros::WallTime::now() < subscriber_timeout)
     {
       ros::WallDuration(0.01).sleep();
@@ -78,13 +78,29 @@ public:
     ros::Rate rate(frequency_);
     for (size_t i = 0; i < num_messages; ++i)
     {
-      geometry_msgs::Point point_message;
-      point_message.x = i;
+      geometry_msgs::PointStamped point_message;
+      point_message.point.x = i;
 
       publisher_.publish(point_message);
 
       rate.sleep();
     }
+  }
+
+  void publishWithHeaderTimestamp(const ros::Time& timestamp)
+  {
+    const ros::WallTime subscriber_timeout = ros::WallTime::now() + ros::WallDuration(1.0);
+    while (publisher_.getNumSubscribers() < 1u && ros::WallTime::now() < subscriber_timeout)
+    {
+      ros::WallDuration(0.01).sleep();
+    }
+
+    ASSERT_GE(publisher_.getNumSubscribers(), 1u);
+
+    geometry_msgs::PointStamped point_message;
+    point_message.header.stamp = timestamp;
+
+    publisher_.publish(point_message);
   }
 
 private:
@@ -94,7 +110,7 @@ private:
 };
 
 /**
- * @brief A dummy point sensor model that uses a fuse_core::ThrottledMessageCallback<geometry_msgs::Point> with a keep
+ * @brief A dummy point sensor model that uses a fuse_core::ThrottledMessageCallback<geometry_msgs::PointStamped> with a keep
  * and drop callback.
  *
  * The callbacks simply count the number of times they are called, for testing purposes. The keep callback also caches
@@ -108,11 +124,12 @@ public:
    *
    * @param[in] throttle_period The throttle period duration in seconds
    */
-  explicit PointSensorModel(const ros::Duration& throttle_period)
+  explicit PointSensorModel(const ros::Duration& throttle_period, bool use_header_timestamp = false)
     : throttled_callback_(std::bind(&PointSensorModel::keepCallback, this, std::placeholders::_1),
-                          std::bind(&PointSensorModel::dropCallback, this, std::placeholders::_1), throttle_period)
+                          std::bind(&PointSensorModel::dropCallback, this, std::placeholders::_1),
+                          throttle_period, false, use_header_timestamp)
   {
-    subscriber_ = node_handle_.subscribe<geometry_msgs::Point>(
+    subscriber_ = node_handle_.subscribe<geometry_msgs::PointStamped>(
         "point", 10, &PointThrottledCallback::callback, &throttled_callback_);
   }
 
@@ -141,18 +158,27 @@ public:
    *
    * @return The last message kept. It would be nullptr if no message has been kept so far
    */
-  const geometry_msgs::Point::ConstPtr getLastKeptMessage() const
+  const geometry_msgs::PointStamped::ConstPtr getLastKeptMessage() const
   {
     return last_kept_message_;
+  }
+
+  /**
+   * @brief Reset the number of kept and dropped messages to zero
+   */
+  void reset()
+  {
+    kept_messages_ = 0;
+    dropped_messages_ = 0;
   }
 
 private:
   /**
    * @brief Keep callback, that counts the number of times it has been called and caches the last message received
    *
-   * @param[in] msg A geometry_msgs::Point message
+   * @param[in] msg A geometry_msgs::PointStamped message
    */
-  void keepCallback(const geometry_msgs::Point::ConstPtr& msg)
+  void keepCallback(const geometry_msgs::PointStamped::ConstPtr& msg)
   {
     ++kept_messages_;
     last_kept_message_ = msg;
@@ -161,9 +187,9 @@ private:
   /**
    * @brief Drop callback, that counts the number of times it has been called
    *
-   * @param[in] msg A geometry_msgs::Point message (not used)
+   * @param[in] msg A geometry_msgs::PointStamped message (not used)
    */
-  void dropCallback(const geometry_msgs::Point::ConstPtr& /*msg*/)
+  void dropCallback(const geometry_msgs::PointStamped::ConstPtr& /*msg*/)
   {
     ++dropped_messages_;
   }
@@ -171,12 +197,12 @@ private:
   ros::NodeHandle node_handle_;  //!< The node handle
   ros::Subscriber subscriber_;   //!< The subscriber
 
-  using PointThrottledCallback = fuse_core::ThrottledMessageCallback<geometry_msgs::Point>;
+  using PointThrottledCallback = fuse_core::ThrottledMessageCallback<geometry_msgs::PointStamped>;
   PointThrottledCallback throttled_callback_;  //!< The throttled callback
 
   size_t kept_messages_{ 0 };                         //!< Messages kept
   size_t dropped_messages_{ 0 };                      //!< Messages dropped
-  geometry_msgs::Point::ConstPtr last_kept_message_;  //!< The last message kept
+  geometry_msgs::PointStamped::ConstPtr last_kept_message_;  //!< The last message kept
 };
 
 
@@ -227,34 +253,126 @@ TEST(ThrottledCallback, DropMessagesIfThrottlePeriodIsGreaterThanPublishPeriod)
   EXPECT_NEAR(expected_dropped_messages, sensor_model.getDroppedMessages(), 1.0);
 }
 
-TEST(ThrottledCallback, AlwaysKeepFirstMessageEvenIfThrottlePeriodIsTooLarge)
+TEST(ThrottledCallback, TestMessageHeaderThrottling)
 {
   // Time should be valid after ros::init() returns in main(). But it doesn't hurt to verify.
   ASSERT_TRUE(ros::Time::waitForValid(ros::WallDuration(1.0)));
 
-  // Start sensor model to listen to messages:
-  const ros::Duration throttled_period(10.0);
-  PointSensorModel sensor_model(throttled_period);
+  constexpr double kThrottleFrequency = 5.0;
+  constexpr double kThrottlePeriodS = 1 / kThrottleFrequency;
 
-  ASSERT_EQ(nullptr, sensor_model.getLastKeptMessage());
+  const ros::Duration throttled_period(kThrottlePeriodS);
+  PointSensorModel sensor_model(throttled_period, true);
 
-  // Publish some messages:
-  const size_t num_messages = 10;
-  const double period = 0.1 * num_messages / throttled_period.toSec();
-  const double frequency = 1.0 / period;
+  constexpr unsigned kPublishToThrottleRatio = 5.0;
+  constexpr double kPublishFrequency = kThrottleFrequency * kPublishToThrottleRatio;
+  constexpr double kPublishPeriodS = 1 / kPublishFrequency;
 
-  PointPublisher publisher(frequency);
-  publisher.publish(num_messages);
+  PointPublisher publisher(kPublishFrequency);
 
-  // Check that regardless of the large throttled period, at least one message is ketpt:
-  EXPECT_EQ(1u, sensor_model.getKeptMessages());
-  EXPECT_EQ(num_messages - 1u, sensor_model.getDroppedMessages());
+  constexpr double kBaseTimeS = 10.0;
+  constexpr double kEpsilonS = 1e-3;
+  ros::Time timestamp;
 
-  // Check the message kept was the first message:
-  const auto last_kept_message = sensor_model.getLastKeptMessage();
-  ASSERT_NE(nullptr, last_kept_message);
-  EXPECT_EQ(0.0, last_kept_message->x);
+  // Initialize the throttled calback with a time just after kBaseTimeS so that kBaseTimeS is the
+  // start timestamp for throttling and the first accepted message will be kThrottlePeriodS after kbaseTimeS
+  timestamp.fromSec(kBaseTimeS + kEpsilonS);
+  publisher.publishWithHeaderTimestamp(timestamp);
+  ros::Duration(0.1).sleep();
+
+  // First message is dropped, just helps find the next expected message period
+  EXPECT_EQ(sensor_model.getKeptMessages(), 0);
+  EXPECT_EQ(sensor_model.getDroppedMessages(), 1);
+
+  // Make sure that messages before the next start of period are dropped
+  // Publish for a full period starting from just before the start of the previous period
+  // No messages should be kept because we haven't crossed into the period after the initial message yet
+  sensor_model.reset();
+  timestamp.fromSec(kBaseTimeS - kEpsilonS);
+  unsigned i = 0;
+  for (; i < kPublishToThrottleRatio; ++i)
+  {
+    timestamp.fromSec(timestamp.toSec() + kPublishPeriodS);
+    publisher.publishWithHeaderTimestamp(timestamp);
+  }
+
+  ros::Duration(0.1).sleep();
+  EXPECT_EQ(sensor_model.getKeptMessages(), 0);
+  EXPECT_EQ(sensor_model.getDroppedMessages(), kPublishToThrottleRatio);
+
+  // Publish for another period, phase aligned to just before the period division
+  // Should keep one message
+  sensor_model.reset();
+
+  for (; i < 2 * kPublishToThrottleRatio; ++i)
+  {
+    timestamp.fromSec(timestamp.toSec() + kPublishPeriodS);
+    publisher.publishWithHeaderTimestamp(timestamp);
+  }
+  ros::Duration(0.1).sleep();
+
+  EXPECT_EQ(sensor_model.getKeptMessages(), 1);
+  EXPECT_EQ(sensor_model.getDroppedMessages(), kPublishToThrottleRatio - 1);
+
+  // Publish one more message which puts us over the next period division, should be kept
+  sensor_model.reset();
+  timestamp.fromSec(timestamp.toSec() + kPublishPeriodS);
+  publisher.publishWithHeaderTimestamp(timestamp);
+  ros::Duration(0.1).sleep();
+
+  EXPECT_EQ(sensor_model.getKeptMessages(), 1);
+  EXPECT_EQ(sensor_model.getDroppedMessages(), 0);
 }
+
+// Test that the call operator is behaving correctly
+TEST(ThrottledCallback, TestCallOperator)
+{
+  constexpr double kThrottlePeriod = 0.1;
+
+  unsigned base_kept = 0;
+  auto base_keep_callback = [&base_kept](const geometry_msgs::PointStamped::ConstPtr & msg){ ++base_kept; };
+
+  unsigned header_timestamp_kept = 0;
+  auto msg_keep_callback =
+    [&header_timestamp_kept](const geometry_msgs::PointStamped::ConstPtr & msg){ ++header_timestamp_kept; };
+
+  fuse_core::ThrottledCallback<std::function<void(const typename geometry_msgs::PointStamped::ConstPtr&)>>
+    base_callback(base_keep_callback, nullptr, ros::Duration(kThrottlePeriod));
+
+  fuse_core::ThrottledMessageCallback<geometry_msgs::PointStamped> message_header_calback(
+    msg_keep_callback, nullptr, ros::Duration(kThrottlePeriod), false, true);
+
+  geometry_msgs::PointStamped point_msg;
+  point_msg.header.stamp.fromSec(0.0);
+
+  geometry_msgs::PointStampedConstPtr msg_const = boost::make_shared<const geometry_msgs::PointStamped>(point_msg);
+
+  // Initialize both callbacks
+  base_callback(msg_const);
+  message_header_calback(msg_const);
+
+  // Neither keeps the first message
+  EXPECT_EQ(base_kept, 0);
+  EXPECT_EQ(header_timestamp_kept, 0);
+
+  ros::Duration(1.0).sleep();
+  // Call with the same message again
+  base_callback(msg_const);
+  message_header_calback(msg_const);
+  // The base callback should keep this one because it's related to elapsed time
+  EXPECT_EQ(base_kept, 1);
+  // The header callback should not keep this one because the header timestamp is the same as the old one
+  EXPECT_EQ(header_timestamp_kept, 0);
+
+  // Advance the header timestamp and check that the header timestamp based throttle keeps it
+  point_msg.header.stamp += ros::Duration(1.0);
+  msg_const = boost::make_shared<const geometry_msgs::PointStamped>(point_msg);
+  message_header_calback(msg_const);
+
+  // The header callback should keep this one because the header timestamp is advanced more than the throttle period
+  EXPECT_EQ(header_timestamp_kept, 1);
+}
+
 
 int main(int argc, char** argv)
 {

--- a/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/acceleration_2d_params.h
@@ -73,6 +73,7 @@ struct Acceleration2DParams : public ParameterBase
 
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period, false);
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
+      nh.getParam("throttle_use_header_timestamps", throttle_use_header_timestamps);
 
       fuse_core::getParamRequired(nh, "topic", topic);
       fuse_core::getParamRequired(nh, "target_frame", target_frame);
@@ -90,6 +91,7 @@ struct Acceleration2DParams : public ParameterBase
     ros::Duration tf_timeout { 0.0 };  //!< The maximum time to wait for a transform to become available
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
+    bool throttle_use_header_timestamps { false };  //!< Whether to throttle using header timestamps
     std::string topic {};
     std::string target_frame {};
     std::vector<size_t> indices;

--- a/fuse_models/include/fuse_models/parameters/imu_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/imu_2d_params.h
@@ -80,6 +80,7 @@ struct Imu2DParams : public ParameterBase
 
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period, false);
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
+      nh.getParam("throttle_use_header_timestamps", throttle_use_header_timestamps);
 
       nh.getParam("remove_gravitational_acceleration", remove_gravitational_acceleration);
       nh.getParam("gravitational_acceleration", gravitational_acceleration);
@@ -122,6 +123,7 @@ struct Imu2DParams : public ParameterBase
     ros::Duration tf_timeout { 0.0 };  //!< The maximum time to wait for a transform to become available
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
+    bool throttle_use_header_timestamps { false };  //!< Whether to throttle using header timestamps
     double gravitational_acceleration { 9.80665 };
     std::string acceleration_target_frame {};
     std::string orientation_target_frame {};

--- a/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/odometry_2d_params.h
@@ -82,6 +82,7 @@ struct Odometry2DParams : public ParameterBase
 
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period, false);
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
+      nh.getParam("throttle_use_header_timestamps", throttle_use_header_timestamps);
 
       fuse_core::getParamRequired(nh, "topic", topic);
 
@@ -120,6 +121,7 @@ struct Odometry2DParams : public ParameterBase
     ros::Duration tf_timeout { 0.0 };  //!< The maximum time to wait for a transform to become available
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
+    bool throttle_use_header_timestamps { false };  //!< Whether to throttle using header timestamps
     std::string topic {};
     std::string pose_target_frame {};
     std::string twist_target_frame {};

--- a/fuse_models/include/fuse_models/parameters/pose_2d_params.h
+++ b/fuse_models/include/fuse_models/parameters/pose_2d_params.h
@@ -76,6 +76,7 @@ struct Pose2DParams : public ParameterBase
 
       fuse_core::getPositiveParam(nh, "throttle_period", throttle_period, false);
       nh.getParam("throttle_use_wall_time", throttle_use_wall_time);
+      nh.getParam("throttle_use_header_timestamps", throttle_use_header_timestamps);
 
       fuse_core::getParamRequired(nh, "topic", topic);
       nh.getParam("target_frame", target_frame);
@@ -107,6 +108,7 @@ struct Pose2DParams : public ParameterBase
     ros::Duration tf_timeout { 0.0 };  //!< The maximum time to wait for a transform to become available
     ros::Duration throttle_period { 0.0 };  //!< The throttle period duration in seconds
     bool throttle_use_wall_time { false };  //!< Whether to throttle using ros::WallTime or not
+    bool throttle_use_header_timestamps { false };  //!< Whether to throttle using header timestamps
     std::string topic {};
     std::string target_frame {};
     std::vector<size_t> position_indices;

--- a/fuse_models/src/acceleration_2d.cpp
+++ b/fuse_models/src/acceleration_2d.cpp
@@ -41,6 +41,8 @@
 #include <pluginlib/class_list_macros.hpp>
 #include <ros/ros.h>
 
+#include <memory>
+
 
 // Register this sensor model with ROS as a plugin.
 PLUGINLIB_EXPORT_CLASS(fuse_models::Acceleration2D, fuse_core::SensorModel)
@@ -64,6 +66,7 @@ void Acceleration2D::onInit()
 
   throttled_callback_.setThrottlePeriod(params_.throttle_period);
   throttled_callback_.setUseWallTime(params_.throttle_use_wall_time);
+  throttled_callback_.setUseHeaderTimestamps(params_.throttle_use_header_timestamps);
 
   if (params_.indices.empty())
   {

--- a/fuse_models/src/imu_2d.cpp
+++ b/fuse_models/src/imu_2d.cpp
@@ -70,6 +70,7 @@ void Imu2D::onInit()
 
   throttled_callback_.setThrottlePeriod(params_.throttle_period);
   throttled_callback_.setUseWallTime(params_.throttle_use_wall_time);
+  throttled_callback_.setUseHeaderTimestamps(params_.throttle_use_header_timestamps);
 
   if (params_.orientation_indices.empty() &&
       params_.linear_acceleration_indices.empty() &&

--- a/fuse_models/src/odometry_2d.cpp
+++ b/fuse_models/src/odometry_2d.cpp
@@ -69,6 +69,7 @@ void Odometry2D::onInit()
 
   throttled_callback_.setThrottlePeriod(params_.throttle_period);
   throttled_callback_.setUseWallTime(params_.throttle_use_wall_time);
+  throttled_callback_.setUseHeaderTimestamps(params_.throttle_use_header_timestamps);
 
   if (params_.position_indices.empty() &&
       params_.orientation_indices.empty() &&

--- a/fuse_models/src/pose_2d.cpp
+++ b/fuse_models/src/pose_2d.cpp
@@ -67,6 +67,7 @@ void Pose2D::onInit()
 
   throttled_callback_.setThrottlePeriod(params_.throttle_period);
   throttled_callback_.setUseWallTime(params_.throttle_use_wall_time);
+  throttled_callback_.setUseHeaderTimestamps(params_.throttle_use_header_timestamps);
 
   if (params_.position_indices.empty() &&
       params_.orientation_indices.empty())

--- a/fuse_optimizers/src/batch_optimizer.cpp
+++ b/fuse_optimizers/src/batch_optimizer.cpp
@@ -169,7 +169,7 @@ void BatchOptimizer::optimizationLoop()
         combined_transaction_ = fuse_core::Transaction::make_shared();
       }
       TRACE_SCOPE_RAII("Optimize");
-      
+
       // Update the graph
       graph_->update(*const_transaction);
       // Optimize the entire graph


### PR DESCRIPTION
Change to `ThrottledCallback` default behavior:
- Align publishes with a whole number multiple of the throttle period for more deterministic throttling.

Add optional behavior to `ThrottledMessageCallback`:
- Add option to use header timestamps
- Subclass will automatically select message header or time-based throttling based on passed flags
  - selection is both in `callback` and `operator()`

Integration
- Add config option to sensor models and set in callback on init

Add tests:
- Verify new default and header timestamp behavior
- Specific test to verify correct version of `operator()` is called